### PR TITLE
Compile 'trie' data structure

### DIFF
--- a/tools/build-trie.ts
+++ b/tools/build-trie.ts
@@ -1,0 +1,52 @@
+/**
+ * Returns a data structure suitable for use by the trie wordlist model.
+ *
+ * Format specification:
+ *
+ *  - the file is a UTF-8 encoded text file
+ *  - new lines are either LF or CRLF
+ *  - the file either consists of a comment or an entry
+ *  - comment lines MUST start with the '#' character
+ *  - entries are one to three columns, separated by the (horizontal) tab
+ *    character
+ *  - column 1 (REQUIRED): the wordform: can have any character except tab, CR,
+ *    LF. surrounding SPACE characters are trimmed.
+ *  - column 2 (optional): the count: a non-negative integer specifying how many
+ *    times this entry has appeared in the corpus. Blank means 'indeterminate'
+ *  - column 3 (optional): comment: an informative comment, ignored by the tool.
+ *
+ * @param sourceFiles an array of the CONTENTS of source files
+ * @return a data structure that will be used internally by the trie wordlist
+ *         implemention. Currently this is an array of [wordlist, count] pairs.
+ */
+export function createTrieDataStructure(sourceFiles: string[]) {
+  // Supports LF or CRLF line terminators.
+  const NEWLINE_SEPARATOR = /\u000d?\u000a/;
+  const TAB = "\t";
+  let contents = sourceFiles.join('\n');
+  // TODO: format validation.
+  let lines = contents.split(NEWLINE_SEPARATOR);
+  // NOTE: this generates a simple array of word forms --- not a trie!
+  // In the future, this function may construct a true trie data structure,
+  // but this is not yet implemented.
+  let result: (string | number)[][] = [];
+  for (let line of lines) {
+    if (line.startsWith('#') || line === "") {
+      continue; // skip comments and empty lines
+    }
+    let [wordform, countText, _comment] = line.split(TAB);
+    // Clean the word form.
+    // TODO: what happens if we get duplicate forms?
+    wordform = wordform.normalize('NFC').trim();
+    countText = countText.trim();
+    let count = parseInt(countText, 10);
+    // When parsing a decimal integer fails (e.g., blank or something else):
+    if (!isFinite(count)) {
+      // TODO: is this the right thing to do?
+      // Treat it like a hapax legonmenom -- it exist
+      count = 1;
+    }
+    result.push([wordform, count]);
+  }
+  return JSON.stringify(result);
+}

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -224,7 +224,7 @@ export default class LexicalModelCompiler {
  */
 function createTrieDataStructure(sourceFiles: string[]) {
   // Supports LF or CRLF line terminators.
-  const NEWLINE_SEPARATOR = /\u0009?\u000a/;
+  const NEWLINE_SEPARATOR = /\u000d?\u000a/;
   const TAB = "\t";
 
   let contents = sourceFiles.join('\n');

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -37,6 +37,9 @@ export default class LexicalModelCompiler {
      *    "authorEmail": "nobody@example.com",
      *    "description": "Example wordlist model"
      *  }
+     * 
+     * For full documentation, see:
+     * https://help.keyman.com/developer/cloud/model_info/1.0/
      */
     let model_info: ModelInfoFile = JSON.parse(fs.readFileSync('../'+model_info_file, 'utf8'));
 

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -9,6 +9,7 @@ import * as ts from "typescript";
 import KmpCompiler from "./kmp-compiler";
 import * as fs from "fs";
 import * as path from "path";
+import { createTrieDataStructure } from "./build-trie";
 
 export default class LexicalModelCompiler {
   compile(modelSource: LexicalModelSource) {
@@ -117,7 +118,7 @@ export default class LexicalModelCompiler {
       case "trie-1.0":
         func += `var model = {};\n`;
         func += `model.backingData = ${createTrieDataStructure(sources)};\n`;
-        func += `LMLayerWorker.loadModel(new modoels.WordListModel(model.backingData));\n`;
+        func += `LMLayerWorker.loadModel(new models.WordListModel(model.backingData));\n`;
         break;
       default:
         this.logError('Unknown model format '+modelSource.format);
@@ -200,64 +201,3 @@ export default class LexicalModelCompiler {
     console.error(require('chalk').red(s));
   };
 };
-
-/**
- * Returns a data structure suitable for use by the trie wordlist model.
- *
- * Format specification:
- *
- *  - the file is a UTF-8 encoded text file
- *  - new lines are either LF or CRLF
- *  - the file either consists of a comment or an entry
- *  - comment lines MUST start with the '#' character
- *  - entries are one to three columns, separated by the (horizontal) tab
- *    character
- *  - column 1 (REQUIRED): the wordform: can have any character except tab, CR,
- *    LF. surrounding SPACE characters are trimmed.
- *  - column 2 (optional): the count: a non-negative integer specifying how many
- *    times this entry has appeared in the corpus. Blank means 'indeterminate'
- *  - column 3 (optional): comment: an informative comment, ignored by the tool.
- *
- * @param sourceFiles an array of the CONTENTS of source files
- * @return a data structure that will be used internally by the trie wordlist
- *         implemention. Currently this is an array of [wordlist, count] pairs.
- */
-function createTrieDataStructure(sourceFiles: string[]) {
-  // Supports LF or CRLF line terminators.
-  const NEWLINE_SEPARATOR = /\u000d?\u000a/;
-  const TAB = "\t";
-
-  let contents = sourceFiles.join('\n');
-  // TODO: format validation.
-  let lines = contents.split(NEWLINE_SEPARATOR);
-
-  // NOTE: this generates a simple array of word forms --- not a trie!
-  // In the future, this function may construct a true trie data structure,
-  // but this is not yet implemented.
-  let result: (string | number)[][] = [];
-  for (let line of lines) {
-    if (line.startsWith('#') || line === "") {
-      continue; // skip comments and empty lines
-    }
-
-    let [wordform, countText, _comment] = line.split(TAB);
-
-    // Clean the word form.
-    // TODO: what happens if we get duplicate forms?
-    wordform = wordform.normalize('NFC').trim();
-
-    countText = countText.trim();
-    let count = parseInt(countText, 10);
-
-    // When parsing a decimal integer fails (e.g., blank or something else):
-    if (!isFinite(count)) {
-      // TODO: is this the right thing to do?
-      // Treat it like a hapax legonmenom -- it exist
-      count = 1;
-    }
-
-    result.push([wordform, count]);
-  }
-
-  return JSON.stringify(result);
-}


### PR DESCRIPTION
This PR implements a simple little TSV parser, and generates a data structure suitable for the initialization of the wordlist model. We call it the "trie" model, but the PR **does not construct a trie**. That's for the future, but this should work with the current version of the wordlist model.

Essentially, this takes a wordlist with the following contents:

```tsv
# This is a comment
armadillo	10	Small armoured mammal
bat	15	Small flying mammal
buffalo	6	Large non-flying mammal
cat	25	Small cheetah
cheetah	7	Large cat
dinosaur	11	Large non-flying non-mammal
dumbo octopus	1	Cute aquatic non-mammal
octopusses	9	THE ONLY RIGHT WAY
```

And compiles it to the following code (pretty-printed):

```js
(function () {
  'use strict';
  var model = {};
  model.backingData = [
    ["armadillo", 10],
    ["bat", 15],
    ["buffalo", 6],
    ["cat", 25],
    ["cheetah", 7],
    ["dinosaur", 11],
    ["dumbo octopus", 1],
    ["octopusses", 9]
  ];
  LMLayerWorker.loadModel(new modoels.WordListModel(model.backingData));
  LMLayerWorker.loadWordBreaker(new DefaultWordBreaker({
    "allowedCharacters": {
      "initials": "abcdefghijklmnopqrstuvwxyz",
      "medials": "abcdefghijklmnopqrstuvwxyz",
      "finals": "abcdefghijklmnopqrstuvwxyz"
    },
    "defaultBreakCharacter": " "
  }));
})();
```