### PR TITLE
Add basic Cree example, exported from Google Sheets

### DIFF
--- a/release/example/crk.wordlist_wahkohtowin/example.crk.wordlist_wahkohtowin.model_info
+++ b/release/example/crk.wordlist_wahkohtowin/example.crk.wordlist_wahkohtowin.model_info
@@ -1,0 +1,12 @@
+{
+    "id": "example.crk.wordlist_wahkohtowin",
+    "name": "Example Plains Cree Wordlist Model",
+    "license": "mit",
+    "version": "1.0.0",
+    "languages": [
+        "crk"
+    ],
+    "authorName": "Eddie Antonio Santos",
+    "authorEmail": "Eddie.Santos@nrc-cnrc.gc.ca",
+    "description": "Example wordlist model for Plains Cree, using a wordlist exported from Google Sheets. The words are terms for kinship (wahkohtowin)."
+}

--- a/release/example/crk.wordlist_wahkohtowin/source/cree-kinship.tsv
+++ b/release/example/crk.wordlist_wahkohtowin/source/cree-kinship.tsv
@@ -1,0 +1,20 @@
+# wâhkôhtowin — kinship terms in Cree		
+# This should be exported as a TSV file!		
+# Word	# Count	# Comment
+nimosôm		my grandfather
+nohkom		my grandmother
+nohtâwiy		my father
+nikâwiy		my mother
+nohcâwîs		my father's brother
+nikâwîs		my mother's sister
+nisis		my mother's brother
+nisikos		my father's sister
+nistês		my older brother
+nimis		my older sister
+nisîmis		my younger sibling
+nikisos		my son
+nitânis		my daughter
+nôsisim		my grandchild
+ninâpêm		my husband
+nitiskwêm		my wife
+niwîkimâkan		my spouse

--- a/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <System>
+    <KeymanDeveloperVersion>12.0.1500.0</KeymanDeveloperVersion>
+    <FileVersion>12.0</FileVersion>
+  </System>
+  <Options>
+    <FollowKeyboardVersion/>
+  </Options>
+  <Info>
+    <Name URL="">Example Plains Cree Wordlist Model</Name>
+    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
+  </Info>
+  <Files>
+    <File>
+      <Name>..\build\example.crk.wordlist_wahkohtowin.model.js</Name>
+      <Description>Lexical model example.en.wordlist.model.js</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.model.js</FileType>
+    </File>
+    <File>
+      <Name>readme.html</Name>
+      <Description>Readme file</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.html</FileType>
+    </File>
+  </Files>
+  <LexicalModels>
+    <LexicalModel>
+      <Name>Example Plains Cree Wordlist Model</Name>
+      <ID>example.crk.wordlist_wahkohotowin</ID>
+      <Version>1.0.0</Version>
+      <Languages>
+        <Language ID="crk">Plains Cree</Language>
+      </Languages>
+    </LexicalModel>
+  </LexicalModels>
+</Package>

--- a/release/example/crk.wordlist_wahkohtowin/source/model.ts
+++ b/release/example/crk.wordlist_wahkohtowin/source/model.ts
@@ -1,0 +1,11 @@
+import LexicalModelCompiler from "../../../../tools/index";
+
+(new LexicalModelCompiler).compile({
+  format: 'trie-1.0',
+  wordBreaking: {
+    allowedCharacters: { initials: 'abcdefghijklmnopqrstuvwxyz', medials: 'abcdefghijklmnopqrstuvwxyz', finals: 'abcdefghijklmnopqrstuvwxyz' },
+    defaultBreakCharacter: ' '
+  },
+  //... metadata ...
+  sources: ['cree-kinship.tsv']
+});


### PR DESCRIPTION
This is an example wordlist that I exported from [Google Sheets](https://docs.google.com/spreadsheets/d/1-3G9RQGN9HPT35_-7T9_6G1zbHGcVPbJP9GhmIh0EHI/edit?usp=sharing). I exported as a TSV, which will work with the compiler implemented in #7.

I wanted to determine the workflow of having my wordlist in a spreadsheet, exporting it, and adding it to the public list of lexical models. This is the result!