### PR TITLE
Removes breaking statement from custom models

### DIFF
--- a/release/example/en.custom/source/example.en.custom.model.kps
+++ b/release/example/en.custom/source/example.en.custom.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example (English) Template Custom Model</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </Info>
   <Files>
     <File>
@@ -31,7 +31,7 @@
     <LexicalModel>
       <Name>Example (English) Template Custom Model</Name>
       <ID>example.en.custom</ID>
-      <Version>0.1.0</Version>
+      <Version>0.1.1</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/tools/index.ts
+++ b/tools/index.ts
@@ -101,8 +101,6 @@ export default class LexicalModelCompiler {
 
     // TODO: add metadata in comment
     const filePrefix: string = `(function() {\n'use strict';\n`;
-    const funcPrefix: string = `com.keyman.lexicalModel.register(`;
-    const funcSuffix: string = `);`;
     const fileSuffix: string = `})();`;
     let func = filePrefix;
 
@@ -112,7 +110,7 @@ export default class LexicalModelCompiler {
 
     switch(modelSource.format) {
       case "custom-1.0":
-        func += funcPrefix + funcSuffix + '\n' + this.transpileSources(sources).join('\n');
+        func += this.transpileSources(sources).join('\n');
         // JSON.stringify(oc) gives the base metadata
         func += `LMLayerWorker.loadModel(new ${modelSource.rootClass}());\n`;
         break;


### PR DESCRIPTION
During the compilation rework, I accidentally left in code that added an extraneous `com.keyman.lexicalModel.register();` statement to custom models.  This broke the LMLayerWorker when attempting to load said model.