### PR TITLE
Fix ID to crk.wordlist_wahkohtowin

### DIFF
--- a/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -29,8 +29,8 @@
   <LexicalModels>
     <LexicalModel>
       <Name>Example Plains Cree Wordlist Model</Name>
-      <ID>example.crk.wordlist_wahkohotowin</ID>
-      <Version>1.0.0</Version>
+      <ID>example.crk.wordlist_wahkohtowin</ID>
+      <Version>1.0.1</Version>
       <Languages>
         <Language ID="crk">Plains Cree</Language>
       </Languages>


### PR DESCRIPTION
Fix the typo in the model ID which was preventing the mobile apps from installing the model.