### PR TITLE
Fixes .kmp bundling.

### DIFF
--- a/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -19,12 +19,6 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.model.js</FileType>
     </File>
-    <File>
-      <Name>readme.html</Name>
-      <Description>Readme file</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.html</FileType>
-    </File>
   </Files>
   <LexicalModels>
     <LexicalModel>

--- a/release/example/en.custom/source/example.en.custom.model.kps
+++ b/release/example/en.custom/source/example.en.custom.model.kps
@@ -20,12 +20,6 @@
       <FileType>.model.js</FileType>
     </File>
     <File>
-      <Name>readme.html</Name>
-      <Description>Readme file</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.html</FileType>
-    </File>
-    <File>
       <Name>welcome.htm</Name>
       <Description>Welcome file</Description>
       <CopyLocation>0</CopyLocation>

--- a/release/example/en.wordlist/source/example.en.wordlist.model.kps
+++ b/release/example/en.wordlist/source/example.en.wordlist.model.kps
@@ -19,12 +19,6 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.model.js</FileType>
     </File>
-    <File>
-      <Name>readme.html</Name>
-      <Description>Readme file</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.html</FileType>
-    </File>
   </Files>
   <LexicalModels>
     <LexicalModel>

--- a/tools/kmp-compiler.ts
+++ b/tools/kmp-compiler.ts
@@ -122,7 +122,8 @@ export default class KmpCompiler {
     }
 
     kmpJsonData.files.forEach(function(value) {
-      zip.file(path.basename(value.name), path.join('../source', value.name));
+      let data = fs.readFileSync(path.join('../source', value.name), 'utf8');
+      zip.file(path.basename(value.name), data);
 
       // Remove path data from files before save
       value.name = path.basename(value.name);


### PR DESCRIPTION
Fixes #15.

The .kps entries for readme.htm were removed so that they didn't break .kmp compilation; the corresponding files do not yet exist in our examples.