### PR TITLE
Fix crash when TSV does not provide a count

### DIFF
--- a/tools/build-trie.ts
+++ b/tools/build-trie.ts
@@ -38,8 +38,9 @@ export function createTrieDataStructure(sourceFiles: string[]) {
     // Clean the word form.
     // TODO: what happens if we get duplicate forms?
     wordform = wordform.normalize('NFC').trim();
-    countText = countText.trim();
+    countText = (countText || '').trim();
     let count = parseInt(countText, 10);
+
     // When parsing a decimal integer fails (e.g., blank or something else):
     if (!isFinite(count)) {
       // TODO: is this the right thing to do?


### PR DESCRIPTION
Small patch that fixes a bug when a TSV file is simply a list of words with no counts -- this is valid according to the spec we laid out. Here's an example of the crash:

```
Building lexical models for release
- Building release/example
Validating model /Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/
Building model /Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/
/Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/build/obj/tools/build-trie.js:43
        countText = countText.trim();
                              ^

TypeError: Cannot read property 'trim' of undefined
    at Object.createTrieDataStructure (/Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/build/obj/tools/build-trie.js:43:31)
    at LexicalModelCompiler.compile (/Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/build/obj/tools/index.js:105:61)
    at Object.<anonymous> (/Users/santoseadmin/Work/lexical-models/release/example/crk.wordlist_general/build/obj/release/example/crk.wordlist_general/source/model.js:4:23)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:283:19)
```