### PR TITLE
Implement new-style word breaking

### DIFF
--- a/release/example/en.wordlist/source/example.en.wordlist.model.kps
+++ b/release/example/en.wordlist/source/example.en.wordlist.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example (English) Template Wordlist Model</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +25,7 @@
     <LexicalModel>
       <Name>Example (English) Template Wordlist Model</Name>
       <ID>example.en.wordlist</ID>
-      <Version>0.1.0</Version>
+      <Version>0.1.1</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/release/example/en.wordlist/source/model.ts
+++ b/release/example/en.wordlist/source/model.ts
@@ -2,10 +2,7 @@ import LexicalModelCompiler from "../../../../tools/index";
 
 (new LexicalModelCompiler).compile({
   format: 'trie-1.0',
-  wordBreaking: {
-    allowedCharacters: { initials: 'abcdefghijklmnopqrstuvwxyz', medials: 'abcdefghijklmnopqrstuvwxyz', finals: 'abcdefghijklmnopqrstuvwxyz' },
-    defaultBreakCharacter: ' '
-  },
+  wordBreaking: 'ascii',
   //... metadata ...
   sources: ['example.tsv']
 });

--- a/tools/lexical-model.ts
+++ b/tools/lexical-model.ts
@@ -1,15 +1,15 @@
+interface ClassBasedWordBreaker {
+  allowedCharacters?: { initials?: string, medials?: string, finals?: string } | string,
+  defaultBreakCharacter?: string
+  sources?: Array<string>;
+  /**
+   * The name of the type to instantiate (without parameters) as the base object for a custom word-breaking model.
+   */
+  rootClass?: string
+}
 
 interface LexicalModel {
   readonly format: 'trie-1.0'|'trie-2.0'|'fst-foma-1.0'|'custom-1.0',
-  readonly wordBreaking?: {
-    allowedCharacters?: { initials?: string, medials?: string, finals?: string } | string,
-    defaultBreakCharacter?: string
-    sources?: Array<string>;
-    /**
-     * The name of the type to instantiate (without parameters) as the base object for a custom word-breaking model.
-     */
-    rootClass?: string
-  },
   //... metadata ...
 }
 
@@ -25,6 +25,7 @@ interface LexicalModelSource extends LexicalModel {
    * The name of the type to instantiate (without parameters) as the base object for a custom predictive model.
    */
   readonly rootClass?: string
+  readonly wordBreaking?: 'ascii' | 'placeholder' | ClassBasedWordBreaker;
 }
 
 interface LexicalModelCompiled extends LexicalModel {


### PR DESCRIPTION
This generates model code compatible with keymanapp/keyman#1755. The main idea here is that the `model.ts` can specify a string for `wordBreaking`, e.g., 

```ts
(new LexicalModelCompiler).compile({
  format: 'trie-1.0',
  wordBreaking: 'ascii',
  sources: ['example.tsv']
});
```

And the compiler will generate the code to instantiate the model.

`example.en.wordlist` has been changed to use this feature and compile with a "built-in" word breaker.

**NOTE**: I strongly suggest tidying up `index.ts` once this PR is merged before adding any more features.