### PR TITLE
Temporarily assign "de" to en.custom.model

### DIFF
--- a/release/example/en.custom/example.en.custom.model_info
+++ b/release/example/en.custom/example.en.custom.model_info
@@ -2,7 +2,7 @@
     "name": "Example (English) Template Custom Model",
     "license": "mit",
     "languages": [
-        "en"
+        "de"
     ],
     "authorName": "Marc Durdin",
     "authorEmail": "support@keyman.com",

--- a/release/example/en.custom/source/example.en.custom.model.kps
+++ b/release/example/en.custom/source/example.en.custom.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example (English) Template Custom Model</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
   </Info>
   <Files>
     <File>
@@ -31,10 +31,9 @@
     <LexicalModel>
       <Name>Example (English) Template Custom Model</Name>
       <ID>example.en.custom</ID>
-      <Version>0.1.1</Version>
+      <Version>0.1.2</Version>
       <Languages>
-        <Language ID="en">English</Language>
-        <Language ID="en-us">English (US)</Language>
+        <Language ID="de">German</Language>
       </Languages>
     </LexicalModel>
   </LexicalModels>


### PR DESCRIPTION
Currently, the embedded apps don't have the ability to selectively install/uninstall lexical models.
When a keyboard is installed, the first associated lexical model gets added.

In order to use the preferred "en.wordlist" model, we're temporarily assigning "en.custom" to German (de)