### PR TITLE
[str.trie_sencoten] Fix the model ID

### DIFF
--- a/release/example/str.trie_sencoten/source/example.str.trie_sencoten.model.kps
+++ b/release/example/str.trie_sencoten/source/example.str.trie_sencoten.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example SENĆOŦEN Trie Model</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
   </Info>
   <Files>
     <File>
@@ -24,8 +24,8 @@
   <LexicalModels>
     <LexicalModel>
       <Name>Example SENĆOŦEN Trie Model</Name>
-      <ID>example.str.trie</ID>
-      <Version>0.1.1</Version>
+      <ID>example.str.trie_sencoten</ID>
+      <Version>0.1.2</Version>
       <Languages>
         <Language ID="str">North Straits Salish</Language>
         <Language ID="str-Latn">SENĆOŦEN</Language>


### PR DESCRIPTION
I was having issues on the mobile app installing example.str.trie_sencoten.model.kmp.

The model filename is `example.str.trie_sencoten.model.js`
so the lexical model ID `example.str.trie` is missing the `_sencoten` portion.

Note, the model will still be unavailable from api.keyman.com because of issue keymanapp/keyman#1793



