### PR TITLE
Use trie-1.0 everywhere

### DIFF
--- a/release/example/str.trie_sencoten/source/example.str.trie_sencoten.model.kps
+++ b/release/example/str.trie_sencoten/source/example.str.trie_sencoten.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example SENĆOŦEN Trie Model</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +25,7 @@
     <LexicalModel>
       <Name>Example SENĆOŦEN Trie Model</Name>
       <ID>example.str.trie_sencoten</ID>
-      <Version>0.1.4</Version>
+      <Version>0.1.5</Version>
       <Languages>
         <Language ID="str">North Straits Salish</Language>
         <Language ID="str-Latn">SENĆOŦEN</Language>

--- a/release/example/str.trie_sencoten/source/model.ts
+++ b/release/example/str.trie_sencoten/source/model.ts
@@ -1,7 +1,7 @@
 import LexicalModelCompiler from "@keymanapp/developer-lexical-model-compiler"; 
 
 (new LexicalModelCompiler).compile({
-  format: 'trie-2.0',
+  format: 'trie-1.0',
   wordBreaking: {
     allowedCharacters: { initials: 'abcdefghijklmnopqrstuvwxyz', medials: 'abcdefghijklmnopqrstuvwxyz', finals: 'abcdefghijklmnopqrstuvwxyz' },
     defaultBreakCharacter: ' '


### PR DESCRIPTION
Depends on keymanapp/keyman#1805 being merged. Since trie-1.0 and trie-2.0 are
identical now, this changes the only model that uses it to use trie-1.0
instead.