### PR TITLE
Simplify existing models' names.

### DIFF
--- a/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/release/example/crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -8,10 +8,10 @@
     <FollowKeyboardVersion/>
   </Options>
   <Info>
-    <Name URL="">Example Plains Cree Wordlist Model</Name>
+    <Name URL="">Example Plains Cree lexical model</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </Info>
   <Files>
     <File>
@@ -23,9 +23,9 @@
   </Files>
   <LexicalModels>
     <LexicalModel>
-      <Name>Example Plains Cree Wordlist Model</Name>
+      <Name>Plains Cree kinship dictionary</Name>
       <ID>example.crk.wordlist_wahkohtowin</ID>
-      <Version>0.1.0</Version>
+      <Version>0.1.1</Version>
       <Languages>
         <Language ID="crk">Plains Cree</Language>
       </Languages>

--- a/release/example/en.custom/source/example.en.custom.model.kps
+++ b/release/example/en.custom/source/example.en.custom.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example (English) Template Custom Model</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
   </Info>
   <Files>
     <File>
@@ -29,9 +29,9 @@
   </Files>
   <LexicalModels>
     <LexicalModel>
-      <Name>Example (English) Template Custom Model</Name>
+      <Name>Template custom lexical models</Name>
       <ID>example.en.custom</ID>
-      <Version>0.1.2</Version>
+      <Version>0.1.3</Version>
       <Languages>
         <Language ID="de">German</Language>
       </Languages>

--- a/release/example/en.mtnt/source/example.en.mtnt.model.kps
+++ b/release/example/en.mtnt/source/example.en.mtnt.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </Info>
   <Files>
     <File>
@@ -23,9 +23,9 @@
   </Files>
   <LexicalModels>
     <LexicalModel>
-      <Name>English language model mined from MTNT</Name>
+      <Name>English dictionary (MTNT)</Name>
       <ID>example.en.mtnt</ID>
-      <Version>0.1.0</Version>
+      <Version>0.1.1</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/release/example/en.wordlist/source/example.en.wordlist.model.kps
+++ b/release/example/en.wordlist/source/example.en.wordlist.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">Example (English) Template Wordlist Model</Name>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
   </Info>
   <Files>
     <File>
@@ -23,9 +23,9 @@
   </Files>
   <LexicalModels>
     <LexicalModel>
-      <Name>Example (English) Template Wordlist Model</Name>
+      <Name>Template for a wordlist dictionary</Name>
       <ID>example.en.wordlist</ID>
-      <Version>0.1.2</Version>
+      <Version>0.1.3</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/release/nrc/str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/str.sencoten/source/nrc.str.sencoten.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </Info>
   <Files>
     <File>
@@ -23,9 +23,9 @@
   </Files>
   <LexicalModels>
     <LexicalModel>
-      <Name>SENĆOŦEN lexical model</Name>
+      <Name>SENĆOŦEN dictionary</Name>
       <ID>nrc.str.sencoten</ID>
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
       <Languages>
         <Language ID="str">North Straits Salish</Language>
         <Language ID="str-Latn">SENĆOŦEN</Language>


### PR DESCRIPTION
The existing lexical models have long names that are difficult to display in the "dictionary selection" screen on the mobile apps. Hence, I've shortened the names for many of these, and removed the word "model" or "lexical model" in names, opting for "dictionary" instead.

I have also bumped version numbers for all models. Note: I have not modified example.str.trie_senchoten because it is completely obsoleted by the nrc.str.sencoten.