### PR TITLE
Add .tsv files to project files

### DIFF
--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -16,6 +16,13 @@
       <FileType>.ts</FileType>
     </File>
     <File>
+      <ID>id_89f63b613fd4156e39e15a1786b03708</ID>
+      <Filename>mtnt.tsv</Filename>
+      <Filepath>source\mtnt.tsv</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.tsv</FileType>
+    </File>
+    <File>
       <ID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ID>
       <Filename>nrc.en.mtnt.model.kps</Filename>
       <Filepath>source\nrc.en.mtnt.model.kps</Filepath>

--- a/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
+++ b/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
@@ -16,6 +16,13 @@
       <FileType>.ts</FileType>
     </File>
     <File>
+      <ID>id_89f63b613fd4156e39e15a1786b03708</ID>
+      <Filename>saanich.tsv</Filename>
+      <Filepath>source\saanich.tsv</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.tsv</FileType>
+    </File>
+    <File>
       <ID>id_c2d6578233d0ef9036f598b2918606ed</ID>
       <Filename>nrc.str.sencoten.model.kps</Filename>
       <Filepath>source\nrc.str.sencoten.model.kps</Filepath>

--- a/sample/example/example.crk.wordlist_wahkohtowin/example.crk.wordlist_wahkohtowin.kpj
+++ b/sample/example/example.crk.wordlist_wahkohtowin/example.crk.wordlist_wahkohtowin.kpj
@@ -16,14 +16,22 @@
       <FileType>.ts</FileType>
     </File>
     <File>
+      <ID>id_89f63b613fd4156e39e15a1786b03708</ID>
+      <Filename>cree-kinship.tsv</Filename>
+      <Filepath>source\cree-kinship.tsv</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.tsv</FileType>
+    </File>
+    <File>
       <ID>id_9fbab87260ce2666ad934188bc9aa1bf</ID>
       <Filename>example.crk.wordlist_wahkohtowin.model.kps</Filename>
       <Filepath>source\example.crk.wordlist_wahkohtowin.model.kps</Filepath>
-      <FileVersion></FileVersion>
+      <FileVersion>0.1.2</FileVersion>
       <FileType>.kps</FileType>
       <Details>
-        <Name>example.crk.wordlist_wahkohtowin</Name>
-        <Copyright>©</Copyright>
+        <Name>Example Plains Cree lexical model</Name>
+        <Copyright>© 2019 National Research Council Canada</Copyright>
+        <Version>0.1.2</Version>
       </Details>
     </File>
     <File>
@@ -60,22 +68,6 @@
       <Filepath>source\..\build\example.crk.wordlist_wahkohtowin.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
-      <ParentFileID>id_9fbab87260ce2666ad934188bc9aa1bf</ParentFileID>
-    </File>
-    <File>
-      <ID>id_356e5d149c1e539356d72698c1e401a6</ID>
-      <Filename>welcome.htm</Filename>
-      <Filepath>source\welcome.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
-      <ParentFileID>id_9fbab87260ce2666ad934188bc9aa1bf</ParentFileID>
-    </File>
-    <File>
-      <ID>id_8da344c4cea6f467013357fe099006f5</ID>
-      <Filename>readme.htm</Filename>
-      <Filepath>source\readme.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
       <ParentFileID>id_9fbab87260ce2666ad934188bc9aa1bf</ParentFileID>
     </File>
   </Files>

--- a/sample/example/example.en.custom/example.en.custom.kpj
+++ b/sample/example/example.en.custom/example.en.custom.kpj
@@ -19,11 +19,12 @@
       <ID>id_532f8759fdea7486ef2670cf444186dd</ID>
       <Filename>example.en.custom.model.kps</Filename>
       <Filepath>source\example.en.custom.model.kps</Filepath>
-      <FileVersion></FileVersion>
+      <FileVersion>0.1.4</FileVersion>
       <FileType>.kps</FileType>
       <Details>
-        <Name>example.en.custom</Name>
-        <Copyright>©</Copyright>
+        <Name>Example (English) Template Custom Model</Name>
+        <Copyright>© 2019 SIL International</Copyright>
+        <Version>0.1.4</Version>
       </Details>
     </File>
     <File>
@@ -66,14 +67,6 @@
       <ID>id_356e5d149c1e539356d72698c1e401a6</ID>
       <Filename>welcome.htm</Filename>
       <Filepath>source\welcome.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
-      <ParentFileID>id_532f8759fdea7486ef2670cf444186dd</ParentFileID>
-    </File>
-    <File>
-      <ID>id_8da344c4cea6f467013357fe099006f5</ID>
-      <Filename>readme.htm</Filename>
-      <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
       <ParentFileID>id_532f8759fdea7486ef2670cf444186dd</ParentFileID>

--- a/sample/example/example.en.wordlist/example.en.wordlist.kpj
+++ b/sample/example/example.en.wordlist/example.en.wordlist.kpj
@@ -16,14 +16,22 @@
       <FileType>.ts</FileType>
     </File>
     <File>
+      <ID>id_89f63b613fd4156e39e15a1786b03708</ID>
+      <Filename>example.tsv</Filename>
+      <Filepath>source\example.tsv</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.tsv</FileType>
+    </File>
+    <File>
       <ID>id_ee631d95e9ecfee2632a3a2d6510cf9a</ID>
       <Filename>example.en.wordlist.model.kps</Filename>
       <Filepath>source\example.en.wordlist.model.kps</Filepath>
-      <FileVersion></FileVersion>
+      <FileVersion>0.1.4</FileVersion>
       <FileType>.kps</FileType>
       <Details>
-        <Name>example.en.wordlist</Name>
-        <Copyright>©</Copyright>
+        <Name>Example (English) Template Wordlist Model</Name>
+        <Copyright>© 2019 SIL International</Copyright>
+        <Version>0.1.4</Version>
       </Details>
     </File>
     <File>
@@ -60,22 +68,6 @@
       <Filepath>source\..\build\example.en.wordlist.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
-      <ParentFileID>id_ee631d95e9ecfee2632a3a2d6510cf9a</ParentFileID>
-    </File>
-    <File>
-      <ID>id_356e5d149c1e539356d72698c1e401a6</ID>
-      <Filename>welcome.htm</Filename>
-      <Filepath>source\welcome.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
-      <ParentFileID>id_ee631d95e9ecfee2632a3a2d6510cf9a</ParentFileID>
-    </File>
-    <File>
-      <ID>id_8da344c4cea6f467013357fe099006f5</ID>
-      <Filename>readme.htm</Filename>
-      <Filepath>source\readme.htm</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.htm</FileType>
       <ParentFileID>id_ee631d95e9ecfee2632a3a2d6510cf9a</ParentFileID>
     </File>
   </Files>


### PR DESCRIPTION
Since Developer can now edit TSV files (accessible from the "Models" tab),
this PR adds the .tsv wordlists to the project files so they'll be accessible in future maintenance.

I'm not incrementing any version numbers because the models aren't being updated.

(Some version info appear in the `example` projects, but that's from when Developer saves the projects)
