### PR TITLE
Use lexical-model-compiler npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The components must be lower case and are:
 * [Node.js](https://nodejs.org/en/)
 * [Git](https://git-scm.com/downloads) for your platform
 * You will need to use **Git Bash** or equivalent to build.
-* [keymanapp/keyman](https://github.com/keymanapp/keyman) repository must be cloned on your system (todo: compilers will be available via npm). See below for configuration.
 
 ### Build instructions
 
@@ -34,16 +33,6 @@ The components must be lower case and are:
   * `-t, -test   Runs tests on models`
   * `-b, -build  Creates compiled models`
   * `-c, -clean  Cleans intermediate and output files`
+  * `-no-npm     Skip all npm steps`
   * `-s          Quiet build`
   * `[target]      The specific model(s) to build, e.g. release or release/example/en.template`
-  
-### Configuring the keymanapp/keyman repo
-
-For a successful build, ensure you have either configured `$KEYMAN_ROOT` to point to the base folder of your local clone of the `keymanapp/keyman` repo, or manually run the following in the Keyman repo:
-
-```
-cd developer/js
-npm install
-npm run build
-npm link .
-```

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ function display_usage {
   echo "  -t || -test   Runs tests on models"
   echo "  -b || -build  Creates compiled models"
   echo "  -c || -clean  Cleans intermediate and output files"
-  echo "  -no-npm       Use and link the lexical model compiler from the keyman repo"
+  echo "  -no-npm       Skip all npm steps"
   echo "  -s            Quiet build"
   echo "  target        The specific model(s) to build, e.g. release or release/example/en.template"
   echo "                If omitted, builds all models"
@@ -38,37 +38,18 @@ MODELINFO_SCHEMA_DIST_JSON="$MODELROOT/tools/model_info.distribution.json"
 #
 # Default is validate model_info, build models
 #
-
 parse_args "$@"
 
-#
-# Pull dependencies
-#
+if [[ "$DO_NPM" = true ]]; then
   # Check if Node.JS/npm is installed.
-type npm >/dev/null ||\
+  type npm >/dev/null ||\
     die "Build environment setup error detected!  Please ensure Node.js is installed!"
 
-if [[ "$DO_NPM" = true ]]; then
+  #
+  # Pull dependencies
+  #
   echo "Dependencies check"
   npm install --no-optional
-else
-  if [[ ! -z "$KEYMAN_ROOT" ]]; then
-    echo "Uninstalling @keymanapp/lexical-model-compiler and @keymanapp/lexical-model-types"
-    npm uninstall @keymanapp/lexical-model-compiler --no-save
-    npm uninstall @keymanapp/lexical-model-types --no-save
-
-    echo "Building lexical model compiler from Keyman repo and publishing via npm link"
-    pushd "$KEYMAN_ROOT"/developer/js
-    npm install
-    npm run build
-    npm link .
-    popd
-
-    # npm link must be done after npm install, because npm install removes linked packages
-    npm link @keymanapp/developer-lexical-model-compiler
-  else
-    die "Environment variable \$KEYMAN_ROOT undefined!"
-  fi
 fi
 
 #
@@ -112,6 +93,4 @@ else
   build_models experimental
 fi
 
-
 # todo copy multi-folder approach from keyboards repo
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@keymanapp/lexical-model-compiler": {
+      "version": "12.0.50",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-12.0.50.tgz",
+      "integrity": "sha512-aUNsAVVLZz93Jdl+m+scStQBiuvqck5HBY9d/TGgn8pC+5Jeg+A/my/0/SQLYD5z/pwN9niaFBe0At6oL95wDw==",
+      "requires": {
+        "commander": "^3.0.0",
+        "node": "^11.7.0",
+        "node-zip": "^1.1.1",
+        "typescript": "^3.2.4",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "@keymanapp/lexical-model-types": {
+      "version": "12.0.100",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-types/-/lexical-model-types-12.0.100.tgz",
+      "integrity": "sha512-7Ggs3Q1QBHMX77ODdwOqvyDytYyJikbSdELTtHzNDg7irZo/oaCvM2YV6lL+qaZF+rTCGntnBle+WaCLOGZy3g=="
+    },
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
@@ -43,6 +60,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -93,8 +115,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -114,7 +135,6 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -123,8 +143,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
+    "@keymanapp/lexical-model-compiler": "^12.0.50",
+    "@keymanapp/lexical-model-types": "^12.0.100",
     "@types/node": "^10.12.18",
     "node": "^11.7.0",
     "node-zip": "^1.1.1",

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -145,16 +145,16 @@ function build_release_model {
   pushd source
 
   # Compile model
-  kmlmc -o "../build/$modelOutputFilename" "./$modelInputFilename" || die "Unable to build .model.js file"
+  npx kmlmc -o "../build/$modelOutputFilename" "./$modelInputFilename" || die "Unable to build .model.js file"
 
   # Compile package
-  kmlmp -o "../build/$modelOutputPackageFilename" "./$modelInputPackageFilename" || die "Unable to build .model.kmp file"
+  npx kmlmp -o "../build/$modelOutputPackageFilename" "./$modelInputPackageFilename" || die "Unable to build .model.kmp file"
 
   popd
 
   # Merge .model_info file
 
-  kmlmi \
+  npx kmlmi \
     --model "$base_model" \
     --outFile "build/$modelInfoFilename" \
     --source "$group/$shortname/$base_model" \


### PR DESCRIPTION
Now that Keyman 12.0 is released, we can update this repo to use the npm dependencies.
@keymanapp/lexical-model-compiler
@keymanapp/lexical-model-types

I've modified `-no-npm` flag to skip all npm steps. 

For my personal testing of `-no-npm`, I uninstalled Developer and 
```
npm uninstall -g @keymanapp/lexical-model-compiler
```
