### PR TITLE
[nrc.str.sencoten] Correct copyright.

### DIFF
--- a/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
+++ b/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
@@ -26,12 +26,12 @@
       <ID>id_c2d6578233d0ef9036f598b2918606ed</ID>
       <Filename>nrc.str.sencoten.model.kps</Filename>
       <Filepath>source\nrc.str.sencoten.model.kps</Filepath>
-      <FileVersion>1.0.3</FileVersion>
+      <FileVersion>1.0.4</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
         <Copyright>© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
+++ b/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
@@ -30,7 +30,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
-        <Copyright>© 2019 National Research Council Canada</Copyright>
+        <Copyright>© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
         <Version>1.0.3</Version>
       </Details>
     </File>

--- a/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
@@ -9,7 +9,7 @@
   </Options>
   <Info>
     <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
-    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Copyright URL="">© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
     <Version>1.0.3</Version>
   </Info>

--- a/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
     <Copyright URL="">© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +25,7 @@
     <LexicalModel>
       <Name>SENĆOŦEN dictionary</Name>
       <ID>nrc.str.sencoten</ID>
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
       <Languages>
         <Language ID="str">North Straits Salish</Language>
         <Language ID="str-Latn">SENĆOŦEN</Language>


### PR DESCRIPTION
Earlier versions claimed the NRC held the copyright to the model data. This is incorrect; the wordlist is handled by Timothy Montler and the W̱SÁNEĆ School Board.