### PR TITLE
fix(nrc.en.mtnt): remove SMP characters

### DIFF
--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,0 +1,5 @@
+# Version History
+
+## 1.0.3
+
+* Removed two extraneous SMP characters from dataset to work around an issue in Keyman (#2374)

--- a/release/nrc/nrc.en.mtnt/source/mtnt.tsv
+++ b/release/nrc/nrc.en.mtnt/source/mtnt.tsv
@@ -14261,7 +14261,6 @@ authenticity	10
 chu	10
 blames	10
 Leinster	10
-🇸	10
 Kellyn	10
 deeds	10
 activist	10
@@ -24307,7 +24306,6 @@ instigator	5
 Petunia	5
 torturing	5
 catered	5
-🇺	5
 headquarters	5
 Baer	5
 dearly	5

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -11,7 +11,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +25,7 @@
     <LexicalModel>
       <Name>English dictionary (MTNT)</Name>
       <ID>nrc.en.mtnt</ID>
-      <Version>0.1.2</Version>
+      <Version>0.1.3</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>


### PR DESCRIPTION
This is a mitigation for keymanapp/keyman#2374.