### PR TITLE
Fix versioning in kps files

### DIFF
--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,5 +1,17 @@
 # Version History
 
-## 1.0.3
+## 0.1.4
 
-* Removed two extraneous SMP characters from dataset to work around an issue in Keyman (#2374)
+* Clean up versioning in .kps package file
+
+## 0.1.3
+
+* Removed two extraneous SMP characters from dataset to work around an issue in Keyman (keymanapp/keyman#2374)
+
+## 0.1.2
+
+* Reorganize `example.en.mtnt` to `nrc.en.mtnt` (#48)
+
+## 0.1.0
+
+* Initial release as `example.en.mtnt` (#42)

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -26,12 +26,12 @@
       <ID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ID>
       <Filename>nrc.en.mtnt.model.kps</Filename>
       <Filepath>source\nrc.en.mtnt.model.kps</Filepath>
-      <FileVersion>0.1.2</FileVersion>
+      <FileVersion>0.1.4</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>English language model mined from MTNT</Name>
         <Copyright>© 2019 National Research Council Canada</Copyright>
-        <Version>0.1.2</Version>
+        <Version>0.1.4</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -5,13 +5,12 @@
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
-    <FollowKeyboardVersion/>
   </Options>
   <Info>
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.3</Version>
+    <Version>0.1.4</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +24,6 @@
     <LexicalModel>
       <Name>English dictionary (MTNT)</Name>
       <ID>nrc.en.mtnt</ID>
-      <Version>0.1.3</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/release/nrc/nrc.str.sencoten/HISTORY.md
+++ b/release/nrc/nrc.str.sencoten/HISTORY.md
@@ -1,0 +1,25 @@
+# Version History
+
+## 1.0.5
+
+* Clean up versioning in .kps package file
+
+## 1.0.4
+
+* Fix copyright (#59)
+
+## 1.0.3
+
+* Add the common word "ȻNES" (#46)
+
+## 1.0.2
+
+* Simplify model name to "dictionary" (#43)
+
+## 1.0.1
+
+* Cleaned up duplicate entries (#41)
+
+## 1.0.0
+
+* Initial release (#40)

--- a/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
+++ b/release/nrc/nrc.str.sencoten/nrc.str.sencoten.kpj
@@ -26,12 +26,12 @@
       <ID>id_c2d6578233d0ef9036f598b2918606ed</ID>
       <Filename>nrc.str.sencoten.model.kps</Filename>
       <Filepath>source\nrc.str.sencoten.model.kps</Filepath>
-      <FileVersion>1.0.4</FileVersion>
+      <FileVersion>1.0.5</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
         <Copyright>© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
-        <Version>1.0.4</Version>
+        <Version>1.0.5</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
@@ -5,13 +5,12 @@
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
-    <FollowKeyboardVersion/>
   </Options>
   <Info>
     <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
     <Copyright URL="">© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
   </Info>
   <Files>
     <File>
@@ -25,7 +24,6 @@
     <LexicalModel>
       <Name>SENĆOŦEN dictionary</Name>
       <ID>nrc.str.sencoten</ID>
-      <Version>1.0.4</Version>
       <Languages>
         <Language ID="str">North Straits Salish</Language>
         <Language ID="str-Latn">SENĆOŦEN</Language>

--- a/sample/example/example.crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/sample/example/example.crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -5,7 +5,6 @@
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
-    <FollowKeyboardVersion/>
   </Options>
   <Info>
     <Name URL="">Example Plains Cree lexical model</Name>
@@ -25,7 +24,6 @@
     <LexicalModel>
       <Name>Plains Cree kinship dictionary</Name>
       <ID>example.crk.wordlist_wahkohtowin</ID>
-      <Version>0.1.2</Version>
       <Languages>
         <Language ID="crk">Plains Cree</Language>
       </Languages>

--- a/sample/example/example.en.custom/source/example.en.custom.model.kps
+++ b/sample/example/example.en.custom/source/example.en.custom.model.kps
@@ -5,7 +5,6 @@
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
-    <FollowKeyboardVersion/>
   </Options>
   <Info>
     <Name URL="">Example (English) Template Custom Model</Name>
@@ -31,7 +30,6 @@
     <LexicalModel>
       <Name>Template custom lexical models</Name>
       <ID>example.en.custom</ID>
-      <Version>0.1.4</Version>
       <Languages>
         <Language ID="en">English</Language>
       </Languages>

--- a/sample/example/example.en.wordlist/source/example.en.wordlist.model.kps
+++ b/sample/example/example.en.wordlist/source/example.en.wordlist.model.kps
@@ -5,7 +5,6 @@
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
-    <FollowKeyboardVersion/>
   </Options>
   <Info>
     <Name URL="">Example (English) Template Wordlist Model</Name>
@@ -25,7 +24,6 @@
     <LexicalModel>
       <Name>Template for a wordlist dictionary</Name>
       <ID>example.en.wordlist</ID>
-      <Version>0.1.4</Version>
       <Languages>
         <Language ID="en">English</Language>
         <Language ID="en-us">English (US)</Language>

--- a/sample/example/example.ta.wordlist/source/example.ta.wordlist.model.kps
+++ b/sample/example/example.ta.wordlist/source/example.ta.wordlist.model.kps
@@ -31,7 +31,6 @@
     <LexicalModel>
       <Name>Template for a wordlist dictionary</Name>
       <ID>example.ta.wordlist</ID>
-      <Version>1.0</Version>
       <Languages>
         <Language ID="ta">Tamil</Language>
       </Languages>


### PR DESCRIPTION
Fixes #62

We decided the package version is what gets used for lexical model version.

For compatibility when compiling lexical model projects in Keyman Developer:
* Remove `<FollowKeyboardVersion/>` in the .kps files
* Remove `<Version> </Version>` tags within the `<LexicalModel>` nodes

Also updated HISTORY.md files for the nrc models (The "latest" mtnt version is 0.1.3)