### PR TITLE
Update lexical-model-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "12.0.50",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-12.0.50.tgz",
-      "integrity": "sha512-aUNsAVVLZz93Jdl+m+scStQBiuvqck5HBY9d/TGgn8pC+5Jeg+A/my/0/SQLYD5z/pwN9niaFBe0At6oL95wDw==",
+      "version": "12.0.66",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-12.0.66.tgz",
+      "integrity": "sha512-a3BkkzSlBd35AcOlqopvRwCLNIWX96nE46Yunpi2DuEA4sUlcrQX06FXoSC6SSPlzBchIY74KXk+hiEiZCk0Xg==",
       "requires": {
         "commander": "^3.0.0",
-        "node": "^11.7.0",
         "node-zip": "^1.1.1",
         "typescript": "^3.2.4",
         "xml2js": "^0.4.19"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^12.0.50",
+    "@keymanapp/lexical-model-compiler": "^12.0.66",
     "@keymanapp/lexical-model-types": "^12.0.100",
     "@types/node": "^10.12.18",
     "node": "^11.7.0",


### PR DESCRIPTION
Update the version of lexical-model-compiler to `12.0.66` so #64 will build.