### PR TITLE
[sil.glk-arab.ptwl1] Convert source from ANSI to UTF-8

### DIFF
--- a/release/sil/sil.glk-arab.ptwl1/HISTORY.md
+++ b/release/sil/sil.glk-arab.ptwl1/HISTORY.md
@@ -1,6 +1,10 @@
 ptwl1 Change History
 ====================
 
+1.0.2 (2020-04-17)
+------------------
+Fix encoding to UTF-8
+
 1.0.1 (2020-04-02)
 ------------------
 Use different punctuation

--- a/release/sil/sil.glk-arab.ptwl1/README.md
+++ b/release/sil/sil.glk-arab.ptwl1/README.md
@@ -3,7 +3,7 @@ ptwl1 lexical model
 
 © 2020 SIL International
 
-Version 1.0.1
+Version 1.0.2
 
 Description
 -----------

--- a/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
+++ b/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
@@ -18,7 +18,7 @@
     <Name URL="">ptwl1</Name>
     <Copyright URL="">© 2020 SIL International</Copyright>
     <Author URL="">RL</Author>
-    <Version URL="">1.0.1</Version>
+    <Version URL="">1.0.2</Version>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.ts
+++ b/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.ts
@@ -1,4 +1,4 @@
-/*Gilaki wordlist ptwl1 1.0 */
+/*Gilaki wordlist ptwl1 1.0.2 */
 
 const source: LexicalModelSource = {
   format: 'trie-1.0',
@@ -6,7 +6,7 @@ const source: LexicalModelSource = {
   sources: ['wordlist.tsv'],
   punctuation: {
     quotesForKeepSuggestion: {
-       open: "«", close: "»"
+       open: "Â«", close: "Â»"
     },
   },
   searchTermToKey: function (term) {
@@ -18,12 +18,12 @@ const source: LexicalModelSource = {
     // This means that MOST accents and diacritics have been "decomposed" and
     // are stored as separate characters. We can then remove these separate
     // characters!
-    // e.g., Å = A + °
+    // e.g., Ã… = A + Â°
     let normalizedTerm = term.normalize('NFD');
    
     // Now, using the pattern above replace each diacritic with the
     // empty string. This effectively removes all diacritics!
-    // e.g.,  a + ° = a
+    // e.g.,  a + Â° = a
     let termWithoutDiacritics = normalizedTerm.replace(COMBINING_DIACRITICAL_MARKS, '')
    
     // The resultant key is normalized and without diacritics


### PR DESCRIPTION
Fixes #89 

The previous sil.glk-arab.ptwl1.model.ts source had ANSI encoding and needed to be UTF-8.
This should fix the quotes.

The "diffs" on the PR look identical, but if you open the [raw](https://raw.githubusercontent.com/keymanapp/lexical-models/master/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.ts) file, you'll see 
```
  quotesForKeepSuggestion: {
       open: "�", close: "�"
    },
```