### PR TITLE
Convert some model.ts from ANSI to UTF-8

### DIFF
--- a/release/sil/sil.bcc-latn.upp_ptwl1/source/sil.bcc-latn.upp_ptwl1.model.ts
+++ b/release/sil/sil.bcc-latn.upp_ptwl1/source/sil.bcc-latn.upp_ptwl1.model.ts
@@ -20,18 +20,18 @@ const source: LexicalModelSource = {
     // are stored as separate characters. We can then remove these separate
     // characters!
     //
-    // e.g., Å ? A + °
+    // e.g., Ã… ? A + Â°
     let normalizedTerm = term.normalize('NFD');
    
     // Now, make it lowercase.
     //
-    // e.g.,  A + ° ? a + °
+    // e.g.,  A + Â° ? a + Â°
     let lowercasedTerm = normalizedTerm.toLowerCase();
    
     // Now, using the pattern above replace each accent and diacritic with the
     // empty string. This effectively removes all accents and diacritics!
     //
-    // e.g.,  a + ° ? a
+    // e.g.,  a + Â° ? a
     //
     // In Balochi we don't want to convert accented letters to their base form.
     // each accented letter should be treated as an equal letter.

--- a/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.ts
+++ b/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.ts
@@ -20,18 +20,18 @@ const source: LexicalModelSource = {
   // are stored as separate characters. We can then remove these separate
   // characters!
   //
-  // e.g., Å ? A + °
+  // e.g., Ã… ? A + Â°
   let normalizedTerm = term.normalize('NFD');
 
   // Now, make it lowercase.
   //
-  // e.g.,  A + ° ? a + °
+  // e.g.,  A + Â° ? a + Â°
   let lowercasedTerm = normalizedTerm.toLowerCase();
 
   // Now, using the pattern above replace each accent and diacritic with the
   // empty string. This effectively removes all accents and diacritics!
   //
-  // e.g.,  a + ° ? a
+  // e.g.,  a + Â° ? a
   let termWithoutDiacritics = lowercasedTerm.replace(COMBINING_DIACRITICAL_MARKS, '')
 
   // The resultant key is lowercased, and has no accents or diacritics.


### PR DESCRIPTION
This converts two more lexical models from ANSI to UTF-8 encoding.
I didn't bump the versions since it only involved comments.

* sil.bcc-latn.upp_ptwl1.model.ts
* wyc_eth.mym-latn.me_en.model.ts
