### PR TITLE
Update compiler to 13.0.109, bump newa version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,24 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "12.0.66",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-12.0.66.tgz",
-      "integrity": "sha512-a3BkkzSlBd35AcOlqopvRwCLNIWX96nE46Yunpi2DuEA4sUlcrQX06FXoSC6SSPlzBchIY74KXk+hiEiZCk0Xg==",
+      "version": "13.0.109",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-13.0.109.tgz",
+      "integrity": "sha512-QRH72i5RPZKU5Q210tAtpaucCYXU6wJQ9F+wR5T1OmkU/ICXwfqr5aElr7JoQMHJYHCYpXZF6y70eRKSKZDDdw==",
       "requires": {
         "commander": "^3.0.0",
-        "node-zip": "^1.1.1",
         "typescript": "^3.2.4",
         "xml2js": "^0.4.19"
       }
     },
     "@keymanapp/lexical-model-types": {
-      "version": "12.0.100",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-types/-/lexical-model-types-12.0.100.tgz",
-      "integrity": "sha512-7Ggs3Q1QBHMX77ODdwOqvyDytYyJikbSdELTtHzNDg7irZo/oaCvM2YV6lL+qaZF+rTCGntnBle+WaCLOGZy3g=="
+      "version": "13.0.107",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-types/-/lexical-model-types-13.0.107.tgz",
+      "integrity": "sha512-9C2F8gKcC5bWR1sHnXAkBu/npaJ8TUBIQ0VqD5pHApOmhDQ2AJTRiLqTrw2yWdnXEitUIPeBLKbuUAide7Ifbw=="
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+      "version": "10.17.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
+      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -86,9 +85,9 @@
       }
     },
     "node": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-11.7.0.tgz",
-      "integrity": "sha512-+r6jtlz4ombaAHlMEHVfzWLmCsq2486TtwLqB2c4D/fPU/IS7ATkZtcHHO28xKWjPkn2bTtTgBBzfQ9qGtYoiw==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-11.15.0.tgz",
+      "integrity": "sha512-Nbzq8qr133iwjGo0ZtzQR0mYeawW2eddYpW/k/+yjgbQW2/zG1a/5QiizVOrJ8yc4hbu3369zkj4dDIEd8f7dg==",
       "requires": {
         "node-bin-setup": "^1.0.0"
       }
@@ -126,23 +125,23 @@
       }
     },
     "typescript": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw=="
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^12.0.66",
-    "@keymanapp/lexical-model-types": "^12.0.100",
-    "@types/node": "^10.12.18",
-    "node": "^11.7.0",
+    "@keymanapp/lexical-model-compiler": "^13.0.109",
+    "@keymanapp/lexical-model-types": "^13.0.107",
+    "@types/node": "^10.17.27",
+    "node": "^11.15.0",
     "node-zip": "^1.1.1",
-    "typescript": "^3.2.4"
+    "typescript": "^3.9.6"
   },
   "devDependencies": {
     "chalk": "^2.4.2",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.23"
   }
 }

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
@@ -1,10 +1,13 @@
 nepal-bhasa Change History
 ====================
 
-1.0 (2020-03-07)
-----------------
-* First compilation - ~21k words
+2.1 (2020-07-13)
+* Rebuild with lexical-model-compiler 13.0.109
 
 2.0 (2020-04-20)
 ----------------
 * 113k words with frequencies extracted from articles in nepalbhasatimes.com
+
+1.0 (2020-03-07)
+----------------
+* First compilation - ~21k words

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
@@ -3,7 +3,7 @@ nepal-bhasa lexical model
 
 (c) 2020 Ananda K Maharjan, Santosh Pradhan
 
-Version 2.0
+Version 2.1
 
 Description
 -----------

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
@@ -19,12 +19,12 @@
       <ID>id_762b4e980ddd27ac947ecb21fcc36e28</ID>
       <Filename>sapradhan.new-newa.nepal_bhasa.model.kps</Filename>
       <Filepath>source\sapradhan.new-newa.nepal_bhasa.model.kps</Filepath>
-      <FileVersion>2.0</FileVersion>
+      <FileVersion>2.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>nepal-bhasa</Name>
         <Copyright>(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
-        <Version>2.0</Version>
+        <Version>2.1</Version>
       </Details>
     </File>
     <File>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
@@ -18,7 +18,7 @@
     <Name URL="">nepal-bhasa</Name>
     <Copyright URL="">(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
     <Author URL="">Santosh Pradhan</Author>
-    <Version URL="">2.0</Version>
+    <Version URL="">2.1</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
Attempts to address #97

* Update lexical model compiler from 12.0.66 to 13.0.109 stable
* Update lexical-model-types from 12.0.100 to 13.0.107

* Bump newa version to trigger rebuild
