### PR TITLE
[newa] Update node version and rebuild Newa model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "node": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-11.15.0.tgz",
-      "integrity": "sha512-Nbzq8qr133iwjGo0ZtzQR0mYeawW2eddYpW/k/+yjgbQW2/zG1a/5QiizVOrJ8yc4hbu3369zkj4dDIEd8f7dg==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-14.15.0.tgz",
+      "integrity": "sha512-FrsP5wcA72CXNgQUk7zIdZm4vciBa/ahzaGC5iv3T0coNvz7hGsiI4pMdqqr0OXlVqyvSxDHzUUrhxlY3Hb2Kg==",
       "requires": {
         "node-bin-setup": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@keymanapp/lexical-model-compiler": "^13.0.109",
     "@keymanapp/lexical-model-types": "^13.0.107",
     "@types/node": "^10.17.27",
-    "node": "^11.15.0",
+    "node": "^14.15.0",
     "node-zip": "^1.1.1",
     "typescript": "^3.9.6"
   },

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
@@ -1,5 +1,7 @@
 nepal-bhasa Change History
 ====================
+2.2 (2020-11-05)
+* Rebuild with lexical-model compiler using node 14.15.0
 
 2.1 (2020-07-13)
 * Rebuild with lexical-model-compiler 13.0.109

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
@@ -3,7 +3,7 @@ nepal-bhasa lexical model
 
 (c) 2020 Ananda K Maharjan, Santosh Pradhan
 
-Version 2.1
+Version 2.2
 
 Description
 -----------

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
@@ -19,12 +19,12 @@
       <ID>id_762b4e980ddd27ac947ecb21fcc36e28</ID>
       <Filename>sapradhan.new-newa.nepal_bhasa.model.kps</Filename>
       <Filepath>source\sapradhan.new-newa.nepal_bhasa.model.kps</Filepath>
-      <FileVersion>2.1</FileVersion>
+      <FileVersion>2.2</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>nepal-bhasa</Name>
         <Copyright>(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
-        <Version>2.1</Version>
+        <Version>2.2</Version>
       </Details>
     </File>
     <File>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
@@ -18,7 +18,7 @@
     <Name URL="">nepal-bhasa</Name>
     <Copyright URL="">(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
     <Author URL="">Santosh Pradhan</Author>
-    <Version URL="">2.1</Version>
+    <Version URL="">2.2</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
Fixes #97 

The Newa model uses SMP characters.

The current version of node in package.json `^11.15.0` generates an invalid Newa lexical-model (splits surrogate pairs).
Updating node to the latest LTS `14.15.0` fixes the compilation.

Also bumped the Newa model version to force a rebuild.