### PR TITLE
SGW ⇒ SGW-ETHI

### DIFF
--- a/release/gff/gff.sgw.gurage/HISTORY.md
+++ b/release/gff/gff.sgw.gurage/HISTORY.md
@@ -1,6 +1,10 @@
 Gurage Lexical Model Change History
 ====================
 
+1.01 (2020-11-07)
+----------------
+* Change of language identifier to sgw-Ethi to synch with keyboards.
+
 1.0 (2020-02-26)
 ----------------
 * Initial Release with UniLex, Wolf Leslau, and Sahle Jingo word lists.

--- a/release/gff/gff.sgw.gurage/README.md
+++ b/release/gff/gff.sgw.gurage/README.md
@@ -3,12 +3,12 @@ Gurage Lexical Model
 
 © 2020 Ge'ez Frontier Foundation
 
-Version 1.0
+Version 1.01
 
 Description
 -------------
 
-This is a Gurage (ጉራጌ , ISO-639-2 sgw) lexical model developed to support predictive text the
+This is a Gurage (ጉራጊና, ISO-639-2 sgw) lexical model developed to support predictive text the
 corresponding GFF Gurage Keyboard.  The lexical model comprises word frequency lists from
 the works of Wolf Leslau ("Ethiopians Speak vol. 2 Chaha"), Shahle Jingo (Gurage Fables)
 and the Sebat Bet Bible of the Ethiopian Bible Society. The respective texts have been normalized

--- a/release/gff/gff.sgw.gurage/gff.sgw.gurage.kpj
+++ b/release/gff/gff.sgw.gurage/gff.sgw.gurage.kpj
@@ -19,12 +19,12 @@
       <ID>id_60dbd3dc5598c8a7525f9f53eae22083</ID>
       <Filename>gff.sgw.gurage.model.kps</Filename>
       <Filepath>source\gff.sgw.gurage.model.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.01</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Gurage</Name>
         <Copyright>© 2020 Ge'ez Frontier Foundation</Copyright>
-        <Version>1.0</Version>
+        <Version>1.01</Version>
       </Details>
     </File>
     <File>

--- a/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
+++ b/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
@@ -46,7 +46,7 @@
       <Name>Gurage</Name>
       <ID>gff.sgw.gurage</ID>
       <Languages>
-        <Language ID="sgw">Sebat Bet Gurage</Language>
+        <Language ID="sgw-Ethi">Sebat Bet Gurage</Language>
       </Languages>
     </LexicalModel>
   </LexicalModels>

--- a/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
+++ b/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.100.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>13.0.114.0</KeymanDeveloperVersion>
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
@@ -18,7 +18,7 @@
     <Name URL="">Gurage</Name>
     <Copyright URL="">© 2020 Ge'ez Frontier Foundation</Copyright>
     <Author URL="">Ge'ez Frontier Foundation</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.01</Version>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.sgw.gurage/source/readme.htm
+++ b/release/gff/gff.sgw.gurage/source/readme.htm
@@ -14,7 +14,7 @@
 <h1>Gurage Lexical Model</h1>
 
 <p>
-This is a Gurage (ጉራጌ , ISO-639-2 sgw) lexical model developed to support predictive text the
+This is a Gurage (ጉራጊና , ISO-639-2 sgw) lexical model developed to support predictive text the
 corresponding GFF Gurage Keyboard.  The lexical model comprises word frequency lists from
 the works of Wolf Leslau ("Ethiopians Speak vol. 2 Chaha"), Shahle Jingo (Gurage Fables)
 and the Sebat Bet Bible of the Ethiopian Bible Society. The respective texts have been normalized


### PR DESCRIPTION
The change of language identifier is made to synchronize with the identifier used in the GFF Gurage keyboard, and is discussed in the Keyman App Issue 3806 (https://github.com/keymanapp/keyman/issues/3806).

While this change is necessary, one issue does arise whereby this lexical model uses the provisional Gurage orthography applied by the GFF Gurage (gff_gurage) keyboard, but  **_not_** by the GFF Gurage Legacy (gff_gurage_legacy) keyboard.  However, both keyboards use the sgw-Ethi identifier.  

Is there any change that could be made to the respective identifiers such that this lexical model is **_only_** used by the gff_gurage keyboard?