### PR TITLE
chore: model compiler update, fix: English (MTNT) model casing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,27 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "13.0.109",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-13.0.109.tgz",
-      "integrity": "sha512-QRH72i5RPZKU5Q210tAtpaucCYXU6wJQ9F+wR5T1OmkU/ICXwfqr5aElr7JoQMHJYHCYpXZF6y70eRKSKZDDdw==",
+      "version": "14.0.226-beta",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.226-beta.tgz",
+      "integrity": "sha512-x4NV0zoVwPSy/FUjUkiZ2O4CudJsZHq8feb4O3u2f9FUsoZlH1xA5s3u9KX+zHL9oPJKTfsrRNRvNgER/HckkA==",
       "requires": {
+        "@keymanapp/models-types": "^14.0.226-beta",
         "commander": "^3.0.0",
-        "typescript": "^3.2.4",
+        "typescript": "^3.8.3",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "@keymanapp/models-types": {
+          "version": "14.0.226-beta",
+          "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.226-beta.tgz",
+          "integrity": "sha512-t7muu6EPmWCMnm7BLeq04qIKBmZQ7PWIUXloUEQL8r7uWdzoOVWFTQr9ieRzSh5xoCbJBz3KRTwui1KYzC6H+g=="
+        }
       }
     },
-    "@keymanapp/lexical-model-types": {
-      "version": "13.0.107",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-types/-/lexical-model-types-13.0.107.tgz",
-      "integrity": "sha512-9C2F8gKcC5bWR1sHnXAkBu/npaJ8TUBIQ0VqD5pHApOmhDQ2AJTRiLqTrw2yWdnXEitUIPeBLKbuUAide7Ifbw=="
+    "@keymanapp/models-types": {
+      "version": "14.0.226-beta",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.226-beta.tgz",
+      "integrity": "sha512-t7muu6EPmWCMnm7BLeq04qIKBmZQ7PWIUXloUEQL8r7uWdzoOVWFTQr9ieRzSh5xoCbJBz3KRTwui1KYzC6H+g=="
     },
     "@types/node": {
       "version": "10.17.27",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^13.0.109",
-    "@keymanapp/lexical-model-types": "^13.0.107",
+    "@keymanapp/lexical-model-compiler": "^14.0.226-beta",
+    "@keymanapp/models-types": "^14.0.226-beta",
     "@types/node": "^10.17.27",
     "node": "^14.15.0",
     "node-zip": "^1.1.1",

--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.1.5
+
+* Enables use of Keyman 14's case-detection & capitalization modeling features
+
 ## 0.1.4
 
 * Clean up versioning in .kps package file

--- a/release/nrc/nrc.en.mtnt/LICENSE.md
+++ b/release/nrc/nrc.en.mtnt/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+© 2019-2021 National Research Council Canada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/release/nrc/nrc.en.mtnt/README.md
+++ b/release/nrc/nrc.en.mtnt/README.md
@@ -30,6 +30,7 @@ Maintainer
 ----------
 
 Eddie Antonio Santos <easantos@ualberta.ca> 🙃
+© 2019-2021 National Research Council Canada
 
 How the corpus was post-processed
 ---------------------------------

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -70,21 +70,5 @@
       <FileType>.js</FileType>
       <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
     </File>
-    <File>
-      <ID>id_c296b5df3dc126e219e0173fcbc1baec</ID>
-      <Filename>LICENSE.md</Filename>
-      <Filepath>source\..\LICENSE.md</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.md</FileType>
-      <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
-    </File>
-    <File>
-      <ID>id_0730bb7c2e8f9ea2438b52e419dd86c9</ID>
-      <Filename>README.md</Filename>
-      <Filepath>README.md</Filepath>
-      <FileVersion></FileVersion>
-      <FileType>.md</FileType>
-      <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
-    </File>
   </Files>
 </KeymanDeveloperProject>

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -26,12 +26,12 @@
       <ID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ID>
       <Filename>nrc.en.mtnt.model.kps</Filename>
       <Filepath>source\nrc.en.mtnt.model.kps</Filepath>
-      <FileVersion>0.1.4</FileVersion>
+      <FileVersion>0.1.5</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>English language model mined from MTNT</Name>
         <Copyright>© 2019 National Research Council Canada</Copyright>
-        <Version>0.1.4</Version>
+        <Version>0.1.5</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -30,7 +30,7 @@
       <FileType>.kps</FileType>
       <Details>
         <Name>English language model mined from MTNT</Name>
-        <Copyright>© 2019 National Research Council Canada</Copyright>
+        <Copyright>© 2019-2021 National Research Council Canada</Copyright>
         <Version>0.1.5</Version>
       </Details>
     </File>
@@ -68,6 +68,22 @@
       <Filepath>source\..\build\nrc.en.mtnt.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
+      <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
+    </File>
+    <File>
+      <ID>id_c296b5df3dc126e219e0173fcbc1baec</ID>
+      <Filename>LICENSE.md</Filename>
+      <Filepath>source\..\LICENSE.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
+      <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
+    </File>
+    <File>
+      <ID>id_0730bb7c2e8f9ea2438b52e419dd86c9</ID>
+      <Filename>README.md</Filename>
+      <Filepath>README.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
       <ParentFileID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ParentFileID>
     </File>
   </Files>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -1,25 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>12.0.1500.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>14.0.180.0</KeymanDeveloperVersion>
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
+    <ExecuteProgram></ExecuteProgram>
+    <MSIFileName></MSIFileName>
+    <MSIOptions></MSIOptions>
   </Options>
+  <StartMenu>
+    <Folder></Folder>
+    <Items/>
+  </StartMenu>
   <Info>
     <Name URL="">English language model mined from MTNT</Name>
-    <Copyright URL="">© 2019 National Research Council Canada</Copyright>
+    <Copyright URL="">© 2019-2021 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.5</Version>
+    <Version URL="">0.1.5</Version>
   </Info>
   <Files>
     <File>
       <Name>..\build\nrc.en.mtnt.model.js</Name>
       <Description>Lexical model nrc.en.mtnt.model.js</Description>
       <CopyLocation>0</CopyLocation>
-      <FileType>.model.js</FileType>
+      <FileType>.js</FileType>
+    </File>
+    <File>
+      <Name>..\LICENSE.md</Name>
+      <Description>File LICENSE.md</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.md</FileType>
+    </File>
+    <File>
+      <Name>..\README.md</Name>
+      <Description>File README.md</Description>
+      <CopyLocation>0</CopyLocation>
+      <FileType>.md</FileType>
     </File>
   </Files>
+  <Keyboards/>
   <LexicalModels>
     <LexicalModel>
       <Name>English dictionary (MTNT)</Name>
@@ -31,4 +51,5 @@
       </Languages>
     </LexicalModel>
   </LexicalModels>
+  <Strings/>
 </Package>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -26,18 +26,6 @@
       <CopyLocation>0</CopyLocation>
       <FileType>.js</FileType>
     </File>
-    <File>
-      <Name>..\LICENSE.md</Name>
-      <Description>File LICENSE.md</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.md</FileType>
-    </File>
-    <File>
-      <Name>..\README.md</Name>
-      <Description>File README.md</Description>
-      <CopyLocation>0</CopyLocation>
-      <FileType>.md</FileType>
-    </File>
   </Files>
   <Keyboards/>
   <LexicalModels>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -10,7 +10,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
   </Info>
   <Files>
     <File>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.ts
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.ts
@@ -1,7 +1,8 @@
 const source: LexicalModelSource = {
   format: 'trie-1.0',
   wordBreaker: 'default',
-  sources: ['mtnt.tsv']
+  sources: ['mtnt.tsv'],
+  languageUsesCasing: true
 };
 
 export default source;


### PR DESCRIPTION
Fixes #108.
Fixes https://github.com/keymanapp/keyman/issues/4115.

Since we're introducing some new predictive-text features for version 14, we should _probably_ shift this repo to a version 14 compiler sooner rather than later, even if it is still in beta.  There were some obstacles for this (see the very-recent https://github.com/keymanapp/keyman/pull/4291 and https://github.com/keymanapp/keyman/pull/4299), but they're now cleared.

This also allows us to enable case-detection behavior for predictive text models on a case-by-case basis.  Since we push English / `sil_euro_latin` as the default language / keyboard pair, it's only natural that our first example of this be the default English model.