### PR TITLE
fix: updates compiler, MTNT due to de-duplication bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,20 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "14.0.226-beta",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.226-beta.tgz",
-      "integrity": "sha512-x4NV0zoVwPSy/FUjUkiZ2O4CudJsZHq8feb4O3u2f9FUsoZlH1xA5s3u9KX+zHL9oPJKTfsrRNRvNgER/HckkA==",
+      "version": "14.0.247-beta",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.247-beta.tgz",
+      "integrity": "sha512-U3p5L+jkojJPc9DUKs07NUeHNpIWgRoSTcMi44QW9k8Pm0MZ+qgcxPco2sIT24BB4Lrh7Yl67I2RG8UbUznS+w==",
       "requires": {
-        "@keymanapp/models-types": "^14.0.226-beta",
+        "@keymanapp/models-types": "^14.0.247-beta",
         "commander": "^3.0.0",
         "typescript": "^3.8.3",
         "xml2js": "^0.4.19"
       },
       "dependencies": {
         "@keymanapp/models-types": {
-          "version": "14.0.226-beta",
-          "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.226-beta.tgz",
-          "integrity": "sha512-t7muu6EPmWCMnm7BLeq04qIKBmZQ7PWIUXloUEQL8r7uWdzoOVWFTQr9ieRzSh5xoCbJBz3KRTwui1KYzC6H+g=="
+          "version": "14.0.247-beta",
+          "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.247-beta.tgz",
+          "integrity": "sha512-W2sYIjFrSN0vBC99kt61I0+SpTBt0GBQPgiEA/sepRYV3jAf0n1yJKxx4+f/CAASmSrYMcGMC2TfZobr2b7MRg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^14.0.226-beta",
+    "@keymanapp/lexical-model-compiler": "^14.0.247-beta",
     "@keymanapp/models-types": "^14.0.226-beta",
     "@types/node": "^10.17.27",
     "node": "^14.15.0",

--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.1.6
+
+* Fixes a bug that broke word weighting, which affected the quality of suggestions (keymanapp/keyman#4504)
+
 ## 0.1.5
 
 * Enables use of Keyman 14's case-detection & capitalization modeling features

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -26,12 +26,12 @@
       <ID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ID>
       <Filename>nrc.en.mtnt.model.kps</Filename>
       <Filepath>source\nrc.en.mtnt.model.kps</Filepath>
-      <FileVersion>0.1.5</FileVersion>
+      <FileVersion>0.1.6</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>English language model mined from MTNT</Name>
         <Copyright>© 2019-2021 National Research Council Canada</Copyright>
-        <Version>0.1.5</Version>
+        <Version>0.1.6</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -17,7 +17,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019-2021 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version URL="">0.1.5</Version>
+    <Version URL="">0.1.6</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
This PR is motivated by https://github.com/keymanapp/keyman/pull/4504.

In short, a compiler bug partially broke the MTNT model's weighting.