### PR TITLE
[jo.isk-cyrl-tj][jo.wbl-cyrl-tj] Add casing

### DIFF
--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/HISTORY.md
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/HISTORY.md
@@ -1,6 +1,10 @@
 Ishkashimi Cyrillic lexical model Change History
 ====================
 
+1.1 (2021-03-05)
+----------------
+* Enable use of Keyman 14's case-detection & capitalization modeling features
+
 1.0 (2020-03-12)
 ----------------
 * Created by JO

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/LICENSE.md
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2020 Tajik International Cultural Relations Organisation
+© 2020-2021 Tajik International Cultural Relations Organisation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/README.md
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/README.md
@@ -1,9 +1,9 @@
 Ishkashimi Cyrillic lexical model
 ===================
 
-© 2020 Tajik International Cultural Relations Organisation
+© 2020-2021 Tajik International Cultural Relations Organisation
 
-Version 1.0
+Version 1.1
 
 Description
 -----------

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.kpj
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.kpj
@@ -19,12 +19,12 @@
       <ID>id_37efb1440e6331ee4c47ff0285d8dc3c</ID>
       <Filename>jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps</Filename>
       <Filepath>source\jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Ishkashimi Cyrillic minimal model</Name>
-        <Copyright>© 2020 Tajik International Cultural Relations Organisation</Copyright>
-        <Version>1.0</Version>
+        <Copyright>© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
+        <Version>1.1</Version>
       </Details>
     </File>
     <File>

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Ishkashimi Cyrillic minimal model</Name>
-    <Copyright URL="">© 2020 Tajik International Cultural Relations Organisation</Copyright>
+    <Copyright URL="">© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
     <Author URL="">JO</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.1</Version>
   </Info>
   <Files>
     <File>

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.ts
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.ts
@@ -10,5 +10,6 @@ const source: LexicalModelSource = {
   format: 'trie-1.0',
   wordBreaker: 'default',
   sources: ['wordlist.tsv'],
+  languageUsesCasing: true,
 };
 export default source;

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/readme.htm
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/readme.htm
@@ -17,7 +17,7 @@
     Ishkashimi Cyrillic lexical model.
 </p>
 
-<p>© 2020 Tajik International Cultural Relations Organisation</p>
+<p>© 2020-2021 Tajik International Cultural Relations Organisation</p>
 
 </body>
 </html>

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/welcome.htm
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/welcome.htm
@@ -21,7 +21,7 @@
 
 <!-- Insert HTML documentation here -->
 
-<p>© 2020 Tajik International Cultural Relations Organisation</p>
+<p>© 2020-2021 Tajik International Cultural Relations Organisation</p>
 
 </body>
 </html>

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/HISTORY.md
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/HISTORY.md
@@ -1,6 +1,10 @@
 Wakhi Cyrillic Change History
 ====================
 
+1.1 (2021-03-05)
+----------------
+* Enable use of Keyman 14's case-detection & capitalization modeling features
+
 1.0 (2020-03-12)
 ----------------
 * Created by JO

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/LICENSE.md
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2020 Tajik International Cultural Relations Organisation
+© 2020-2021 Tajik International Cultural Relations Organisation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/README.md
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/README.md
@@ -1,9 +1,9 @@
 Wakhi Cyrillic lexical model
 ===================
 
-© 2020 Tajik International Cultural Relations Organisation
+© 2020-2021 Tajik International Cultural Relations Organisation
 
-Version 1.0
+Version 1.1
 
 Description
 -----------

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.kpj
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.kpj
@@ -2,7 +2,7 @@
 <KeymanDeveloperProject>
   <Options>
     <BuildPath>$PROJECTPATH\build</BuildPath>
-    <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
+    <CompilerWarningsAsErrors>False</CompilerWarningsAsErrors>
     <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>True</CheckFilenameConventions>
     <ProjectType>lexicalmodel</ProjectType>
@@ -19,12 +19,12 @@
       <ID>id_c19d7de11db311d4ce9c8bb114ca0b7c</ID>
       <Filename>jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps</Filename>
       <Filepath>source\jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Wakhi Cyrillic</Name>
-        <Copyright>© 2020 Tajik International Cultural Relations Organisation</Copyright>
-        <Version>1.0</Version>
+        <Copyright>© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
+        <Version>1.1</Version>
       </Details>
     </File>
     <File>

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Wakhi Cyrillic</Name>
-    <Copyright URL="">© 2020 Tajik International Cultural Relations Organisation</Copyright>
+    <Copyright URL="">© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
     <Author URL="">JO</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.1</Version>
   </Info>
   <Files>
     <File>

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.ts
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.ts
@@ -10,5 +10,6 @@ const source: LexicalModelSource = {
   format: 'trie-1.0',
   wordBreaker: 'default',
   sources: ['wordlist.tsv'],
+  languageUsesCasing: true,
 };
 export default source;

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/readme.htm
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/readme.htm
@@ -17,7 +17,7 @@
     Wakhi Cyrillic lexical model.
 </p>
 
-<p>© 2020 Tajik International Cultural Relations Organisation</p>
+<p>© 2020-2021 Tajik International Cultural Relations Organisation</p>
 
 </body>
 </html>

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/welcome.htm
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/welcome.htm
@@ -21,7 +21,7 @@
 
 <!-- Insert HTML documentation here -->
 
-<p>© 2020 Tajik International Cultural Relations Organisation </p>
+<p>© 2020-2021 Tajik International Cultural Relations Organisation </p>
 
 </body>
 </html>


### PR DESCRIPTION
This adds casing to jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal and jo.wbl-cyrl-tj.wakhi_cyrillic_minimal lexical models.

The existing keyboards and lexical models were using -cyrl-tj in the BCP 47 code, so I turned off "treat warnings as errors" to allow the non-canonical tags to remain.