### PR TITLE
fix: Update LM compiler version and support Android 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,20 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "14.0.247-beta",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.247-beta.tgz",
-      "integrity": "sha512-U3p5L+jkojJPc9DUKs07NUeHNpIWgRoSTcMi44QW9k8Pm0MZ+qgcxPco2sIT24BB4Lrh7Yl67I2RG8UbUznS+w==",
+      "version": "14.0.265-beta",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.265-beta.tgz",
+      "integrity": "sha512-9EdaeZlUuHnox5XaSjwrS0JuU+A0l5IbGJy36tspoIGs0H6NDx5XCGRvrde4bVSdQlrWU+iZBYBynCAC2TAepQ==",
       "requires": {
-        "@keymanapp/models-types": "^14.0.247-beta",
+        "@keymanapp/models-types": "^14.0.265-beta",
         "commander": "^3.0.0",
         "typescript": "^3.8.3",
         "xml2js": "^0.4.19"
-      },
-      "dependencies": {
-        "@keymanapp/models-types": {
-          "version": "14.0.247-beta",
-          "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.247-beta.tgz",
-          "integrity": "sha512-W2sYIjFrSN0vBC99kt61I0+SpTBt0GBQPgiEA/sepRYV3jAf0n1yJKxx4+f/CAASmSrYMcGMC2TfZobr2b7MRg=="
-        }
       }
     },
     "@keymanapp/models-types": {
-      "version": "14.0.226-beta",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.226-beta.tgz",
-      "integrity": "sha512-t7muu6EPmWCMnm7BLeq04qIKBmZQ7PWIUXloUEQL8r7uWdzoOVWFTQr9ieRzSh5xoCbJBz3KRTwui1KYzC6H+g=="
+      "version": "14.0.265-beta",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.265-beta.tgz",
+      "integrity": "sha512-yQot7nEHlIJ38AxBxARLH68572wYuamvpeIfEs4TtS9a85DkAemEZeTHBcjr+H01HiBOPv4eSS7kRN2Rpir8zQ=="
     },
     "@types/node": {
       "version": "10.17.27",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^14.0.247-beta",
-    "@keymanapp/models-types": "^14.0.226-beta",
+    "@keymanapp/lexical-model-compiler": "^14.0.265-beta",
+    "@keymanapp/models-types": "^14.0.265-beta",
     "@types/node": "^10.17.27",
     "node": "^14.15.0",
     "node-zip": "^1.1.1",

--- a/release/katelem/katelem.ann-latn.getat/HISTORY.md
+++ b/release/katelem/katelem.ann-latn.getat/HISTORY.md
@@ -1,6 +1,10 @@
 Getat Change History
 ====================
 
+1.0.1 (2021-03-19)
+------------------
+* Fixes a bug that prevented use on Android 5.0 devices (keymanapp/keyman#4718)
+
 1.0 (2020-05-14)
 ----------------
 * Created by Rogers Katelem Edeh

--- a/release/katelem/katelem.ann-latn.getat/README.md
+++ b/release/katelem/katelem.ann-latn.getat/README.md
@@ -3,7 +3,7 @@ Getat lexical model
 
 © 2020 Rogers Katelem Edeh
 
-Version 1.0
+Version 1.0.1
 
 Description
 -----------

--- a/release/katelem/katelem.ann-latn.getat/katelem.ann-latn.getat.kpj
+++ b/release/katelem/katelem.ann-latn.getat/katelem.ann-latn.getat.kpj
@@ -19,12 +19,12 @@
       <ID>id_0850757cc248c5de84f5a43521c81e04</ID>
       <Filename>katelem.ann-latn.getat.model.kps</Filename>
       <Filepath>source\katelem.ann-latn.getat.model.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.0.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Getat</Name>
         <Copyright>© 2020 Rogers Katelem Edeh</Copyright>
-        <Version>1.0</Version>
+        <Version>1.0.1</Version>
       </Details>
     </File>
     <File>

--- a/release/katelem/katelem.ann-latn.getat/source/katelem.ann-latn.getat.model.kps
+++ b/release/katelem/katelem.ann-latn.getat/source/katelem.ann-latn.getat.model.kps
@@ -18,7 +18,7 @@
     <Name URL="">Getat</Name>
     <Copyright URL="">© 2020 Rogers Katelem Edeh</Copyright>
     <Author URL="mailto:katelem247@gmail.com">Rogers Katelem Edeh</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.0.1</Version>
   </Info>
   <Files>
     <File>

--- a/release/katelem/katelem.ann-latn.getat/source/welcome.htm
+++ b/release/katelem/katelem.ann-latn.getat/source/welcome.htm
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<h1>Start Using Obolo Lexcica Modell</h1>
+<h1>Start Using Obolo Lexcica Model</h1>
 
 <p>Obolo Lexcical 1.0</p>
 

--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.1.7 (2021-03-19)
+
+* Fixes a bug that prevented use on Android 5.0 devices (keymanapp/keyman#4718)
+
 ## 0.1.6
 
 * Fixes a bug that broke word weighting, which affected the quality of suggestions (keymanapp/keyman#4504)

--- a/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
+++ b/release/nrc/nrc.en.mtnt/nrc.en.mtnt.kpj
@@ -26,12 +26,12 @@
       <ID>id_dbb5a988f0d2f501a6d48d1d9987c55f</ID>
       <Filename>nrc.en.mtnt.model.kps</Filename>
       <Filepath>source\nrc.en.mtnt.model.kps</Filepath>
-      <FileVersion>0.1.6</FileVersion>
+      <FileVersion>0.1.7</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>English language model mined from MTNT</Name>
         <Copyright>© 2019-2021 National Research Council Canada</Copyright>
-        <Version>0.1.6</Version>
+        <Version>0.1.7</Version>
       </Details>
     </File>
     <File>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -17,7 +17,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019-2021 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version URL="">0.1.6</Version>
+    <Version URL="">0.1.7</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
Fixes #124.

I haven't updated copyright dates because the change is inconsequential and actually only a version increment to get the new version deployed.