### PR TITLE
chore: Update compiler to 14.0.272

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,20 @@
   "requires": true,
   "dependencies": {
     "@keymanapp/lexical-model-compiler": {
-      "version": "14.0.271",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.271.tgz",
-      "integrity": "sha512-G/v1GfEiumN39McMUyZAhY/wOUhWQ535iCN98Ce0iOwIY9hLXxYi6kA1CqmOOEuTMgAzO8olGqs+U/CGb6XZ3g==",
+      "version": "14.0.272",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-14.0.272.tgz",
+      "integrity": "sha512-qkulypLro7GFET1oTXKZOZu2t3evdJ+dv4YYWwdccsMLUR5/bhbUfK9VNuFdyxN442YgPWC9wuqP/1T7vlAnoQ==",
       "requires": {
-        "@keymanapp/models-types": "^14.0.271",
+        "@keymanapp/models-types": "^14.0.272",
         "commander": "^3.0.0",
         "typescript": "^3.8.3",
         "xml2js": "^0.4.19"
       }
     },
     "@keymanapp/models-types": {
-      "version": "14.0.271",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.271.tgz",
-      "integrity": "sha512-8MI9GUP5uoFsH6HuZ8FhGAMHl0283ZRiatAq0ZhGf8y1lVUp5ZqaJdoLn7O5bz+6+33ur9fkKRrV6zrkrXh2uw=="
+      "version": "14.0.272",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-14.0.272.tgz",
+      "integrity": "sha512-HUVBnUn6S4gxrfAPVzjHyEtvMgUZ7DQmvpp/DTL2AhOJKcV5VLWSEUMXBgFZrBcucsOWcUiIs8IsPpaXIaNmkg=="
     },
     "@types/node": {
       "version": "10.17.27",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^14.0.271",
-    "@keymanapp/models-types": "^14.0.271",
+    "@keymanapp/lexical-model-compiler": "^14.0.272",
+    "@keymanapp/models-types": "^14.0.272",
     "@types/node": "^10.17.27",
     "node": "^14.15.0",
     "node-zip": "^1.1.1",


### PR DESCRIPTION
This updates the lexical model compiler which downgrades non-canonical BCP-47 tags to Info