### PR TITLE
[fv.bea.tsaadane] Initial commit for fv-bea-tsaadane

### DIFF
--- a/release/fv/fv.bea.tsaadane/.gitignore
+++ b/release/fv/fv.bea.tsaadane/.gitignore
@@ -1,0 +1,5 @@
+# Only specific files may be added to repository for external references
+*
+!external_source
+!README_EXTERNAL.md
+!.gitignore

--- a/release/fv/fv.bea.tsaadane/README_EXTERNAL.md
+++ b/release/fv/fv.bea.tsaadane/README_EXTERNAL.md
@@ -1,0 +1,15 @@
+Dane-Z̲aa Z̲áágéʔ Lexical Model
+----------------------
+
+This is a simple predictive text model for Dane-Z̲aa Z̲áágéʔ (BCP47: bea).
+
+Credits
+-------
+
+The word list was compiled based on the `Tsaaʔ Dane - Beaver People` FirstVoices website.
+See here: https://www.firstvoices.com/explore/FV/sections/Data/Athabascan/Beaver/Tsaa%CA%94%20Dane%20-%20Beaver%20People
+
+This model is maintained by the [FirstVoices][FIRSTVOICES] team  in the [First Peoples' Cultural Council][FPCC].
+
+[FPCC]: https://www.fpcc.ca/
+[FIRSTVOICES]: https://www.firstvoices.com/

--- a/release/fv/fv.bea.tsaadane/external_source
+++ b/release/fv/fv.bea.tsaadane/external_source
@@ -1,3 +1,3 @@
-fv.bea.tsaadane.model_info=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info
-fv.bea.tsaadane.model.kmp=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp
-fv.bea.tsaadane.model.js=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.js
+fv.bea.tsaadane.model_info https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info 3c386f4c7abb2444a2eeb891a75c53bf0a18be6305d801ffa77c3b14b8acee46
+fv.bea.tsaadane.model.kmp https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp 705abbd67b104f2e6dd55095befbdea2bcfc61796e89ecaac5f0a6c536e4c224
+fv.bea.tsaadane.model.js https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.js 0ad792674ee8ff752aa9c353e88c1a4013b17bbb35636759fcca494d47886442

--- a/release/fv/fv.bea.tsaadane/external_source
+++ b/release/fv/fv.bea.tsaadane/external_source
@@ -1,3 +1,3 @@
-fv.bea.tsaadane.model_info https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info 27d1a8015bebaab80267deeae714b2665c8918649df07c8e700e8e1342fc3efd
-fv.bea.tsaadane.model.kmp https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp 705abbd67b104f2e6dd55095befbdea2bcfc61796e89ecaac5f0a6c536e4c224
+fv.bea.tsaadane.model_info https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info 3148a5b03ab2f645159d578de556a51e9a2f85dcd5e5e19010714a162f3ac4e1
+fv.bea.tsaadane.model.kmp https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp b44db9d753f31e5434d6f61c129b9fc2b7672553b959dee00f90991fdd61bfaa
 fv.bea.tsaadane.model.js https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.js 0ad792674ee8ff752aa9c353e88c1a4013b17bbb35636759fcca494d47886442

--- a/release/fv/fv.bea.tsaadane/external_source
+++ b/release/fv/fv.bea.tsaadane/external_source
@@ -1,0 +1,3 @@
+fv.bea.tsaadane.model_info=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info
+fv.bea.tsaadane.model.kmp=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp
+fv.bea.tsaadane.model.js=https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.js

--- a/release/fv/fv.bea.tsaadane/external_source
+++ b/release/fv/fv.bea.tsaadane/external_source
@@ -1,3 +1,3 @@
-fv.bea.tsaadane.model_info https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info 3c386f4c7abb2444a2eeb891a75c53bf0a18be6305d801ffa77c3b14b8acee46
+fv.bea.tsaadane.model_info https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model_info 27d1a8015bebaab80267deeae714b2665c8918649df07c8e700e8e1342fc3efd
 fv.bea.tsaadane.model.kmp https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.kmp 705abbd67b104f2e6dd55095befbdea2bcfc61796e89ecaac5f0a6c536e4c224
 fv.bea.tsaadane.model.js https://static.firstvoices.io/keyboards/lexical-models/fv.bea.tsaadane/fv.bea.tsaadane.model.js 0ad792674ee8ff752aa9c353e88c1a4013b17bbb35636759fcca494d47886442

--- a/resources/compile.sh
+++ b/resources/compile.sh
@@ -170,9 +170,9 @@ function build_release_model {
 
   if [ -f .source_is_binary ]; then
     # All these files must exist, so we'll fail if they are not present
-    cp $modelInfoFilename build/$modelInfoFilename
-    cp source/$modelOutputFilename build/$modelOutputFilename
-    cp source/$modelOutputPackageFilename build/$modelOutputPackageFilename
+    cp $modelInfoFilename build/$modelInfoFilename || die
+    cp source/$modelOutputFilename build/$modelOutputFilename || die
+    cp source/$modelOutputPackageFilename build/$modelOutputPackageFilename || die
   else
     pushd source
 

--- a/resources/external.sh
+++ b/resources/external.sh
@@ -121,6 +121,8 @@ retrieve_external_binary_model() {
   # We'll read .source line by line...
   touch .source_is_binary
 
+  mkdir -p source
+
   # for each line in the external_source file
   while IFS="" read -r line
   do
@@ -132,8 +134,10 @@ retrieve_external_binary_model() {
     local sha256="${BASH_REMATCH[3]}"
     [[ $filename =~ \.\. ]] && die "path cannot contain .."
     [[ $filename =~ ^/ ]] && die "path cannot start with /"
-    curl -s -L "$url" --output "$filename" --create-dirs || die "Unable to download $filename"
-    echo "$sha256 $filename" | sha256sum -c --quiet || die "Invalid checksum for $filename"
+    local path=
+    [[ ! $filename =~ .model_info$ ]] && path=source/
+    curl -s -L "$url" --output "$path$filename" --create-dirs || die "Unable to download $filename"
+    echo "$sha256 $path$filename" | sha256sum -c --quiet || die "Invalid checksum for $filename"
   done < external_source
 }
 


### PR DESCRIPTION
Hi Keyman team!
Testing our process out with a model for Dane-Z̲aa Z̲áágéʔ, keyboard should be: https://keyman.com/keyboards/fv_dane_zaa_zaage

Hashes:

fv.bea.tsaadane.model.js
0ad792674ee8ff752aa9c353e88c1a4013b17bbb35636759fcca494d47886442  

fv.bea.tsaadane.model.kmp
2132bc5a1f137a48c3189654f7aa92bdee5ad352bc850c6986a51652fed1ea31  

fv.bea.tsaadane.model_info
aca69c5d168437cfaaa3c9b6fe85e36c1df71904a0ce971c357ae42292313be0

I wasn't sure what format to include these in the `release/fv/fv.bea.tsaadane/external_source` file.