### PR TITLE
[en.mtnt] - Remove symbols and typos of contractions

### DIFF
--- a/release/nrc/nrc.en.mtnt/HISTORY.md
+++ b/release/nrc/nrc.en.mtnt/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.1.8 (2022-04-13)
+
+* Removed typos and non-Latin characters
+
 ## 0.1.7 (2021-03-19)
 
 * Fixes a bug that prevented use on Android 5.0 devices (keymanapp/keyman#4718)

--- a/release/nrc/nrc.en.mtnt/LICENSE.md
+++ b/release/nrc/nrc.en.mtnt/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-© 2019-2021 National Research Council Canada
+© 2019-2022 National Research Council Canada
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/nrc/nrc.en.mtnt/README.md
+++ b/release/nrc/nrc.en.mtnt/README.md
@@ -30,7 +30,7 @@ Maintainer
 ----------
 
 Eddie Antonio Santos <easantos@ualberta.ca> 🙃
-© 2019-2021 National Research Council Canada
+© 2019-2022 National Research Council Canada
 
 How the corpus was post-processed
 ---------------------------------

--- a/release/nrc/nrc.en.mtnt/README.md
+++ b/release/nrc/nrc.en.mtnt/README.md
@@ -30,7 +30,7 @@ Maintainer
 ----------
 
 Eddie Antonio Santos <easantos@ualberta.ca> 🙃
-© 2019-2022 National Research Council Canada
+© National Research Council Canada
 
 How the corpus was post-processed
 ---------------------------------

--- a/release/nrc/nrc.en.mtnt/source/mtnt.tsv
+++ b/release/nrc/nrc.en.mtnt/source/mtnt.tsv
@@ -374,7 +374,6 @@ sub	988
 women	985
 under	981
 based	978
-dont	977
 exactly	976
 cool	972
 months	971
@@ -623,7 +622,6 @@ city	545
 alone	545
 favorite	544
 parents	543
-thats	542
 human	541
 fair	540
 longer	540
@@ -2162,7 +2160,6 @@ ugly	135
 loving	135
 cheese	135
 automatically	135
-theres	135
 owned	135
 freedom	135
 boyfriend	135
@@ -2430,7 +2427,6 @@ cable	116
 clan	116
 superior	116
 consistently	116
-hes	116
 existed	116
 convinced	116
 ultimately	116
@@ -3258,7 +3254,6 @@ nights	80
 forest	80
 Jets	80
 upvotes	80
-wouldnt	80
 courses	80
 symptoms	80
 roughly	80
@@ -3515,7 +3510,6 @@ label	73
 lean	73
 charging	73
 settle	73
-arent	73
 passes	73
 refused	73
 folder	73
@@ -4049,7 +4043,6 @@ headed	61
 embarrassing	61
 FB	61
 images	61
-theyre	61
 plug	61
 PG	61
 viewers	61
@@ -4730,7 +4723,6 @@ documents	50
 matchup	50
 destruction	50
 landed	50
-shes	50
 detailed	50
 commenting	50
 hack	50
@@ -5681,7 +5673,6 @@ Lastly	39
 enforcement	39
 operation	39
 stem	39
-shouldnt	39
 gamer	39
 declare	39
 Minister	39
@@ -5972,7 +5963,6 @@ commission	37
 NK	37
 tags	37
 upgrading	37
-couldnt	37
 factions	37
 mortal	37
 misunderstood	37
@@ -6669,7 +6659,6 @@ inconsistent	32
 alas	32
 dull	32
 veggies	32
-mans	32
 variant	32
 geared	32
 adapter	32
@@ -6883,7 +6872,6 @@ authentic	31
 mechs	31
 grief	31
 purge	31
-aint	31
 hoped	31
 continuously	31
 overseas	31
@@ -8238,7 +8226,6 @@ Sixers	23
 dedication	23
 designers	23
 outline	23
-hasnt	23
 roaming	23
 DLCs	23
 headline	23
@@ -8658,7 +8645,6 @@ fundamentals	22
 slipped	22
 rec	22
 Duterte	22
-youll	22
 U.K	22
 Genesis	22
 inflated	22
@@ -8993,7 +8979,6 @@ chicks	21
 drafting	21
 DK	21
 trunk	21
-imma	21
 Yuri	21
 thr	21
 shuttle	21
@@ -9739,7 +9724,6 @@ heritage	18
 nest	18
 owed	18
 endlessly	18
-someones	18
 chime	18
 Costa	18
 colleges	18
@@ -10187,7 +10171,6 @@ compact	17
 cane	17
 Betty	17
 airline	17
-youve	17
 joystick	17
 thier	17
 allegedly	17
@@ -10224,7 +10207,6 @@ bloated	17
 primaries	17
 RF	17
 ahem	17
-Wheres	17
 CV	17
 crippling	17
 sums	17
@@ -10394,7 +10376,6 @@ streaks	17
 proxy	17
 meteor	17
 smirk	17
-yall	17
 stray	17
 pond	17
 m8	17
@@ -10694,7 +10675,6 @@ respecting	16
 Nakamura	16
 skirt	16
 disclose	16
-cmon	16
 Archie	16
 sourced	16
 Ehh	16
@@ -10960,7 +10940,6 @@ survivability	16
 intellectually	16
 waitlist	16
 graders	16
-werent	16
 investigating	16
 qualifying	16
 flawless	16
@@ -11478,7 +11457,6 @@ adamant	14
 coherent	14
 consensual	14
 crafted	14
-Heres	14
 notices	14
 cyber	14
 colonies	14
@@ -12499,12 +12477,10 @@ legitimacy	13
 Dembele	13
 helm	13
 pony	13
-todays	13
 brah	13
 Einstein	13
 underperforming	13
 drained	13
-youd	13
 RPM	13
 SCP	13
 Midway	13
@@ -12744,7 +12720,6 @@ Reposti	12
 AST	12
 crab	12
 hahahahahaha	12
-wouldve	12
 nothin	12
 martyr	12
 CIG	12
@@ -13389,7 +13364,6 @@ hesitation	11
 Clarke	11
 Rusev	11
 hookers	11
-theyd	11
 Chromebook	11
 glitched	11
 sleeps	11
@@ -13645,7 +13619,6 @@ mashing	11
 Aikido	11
 lodge	11
 tweaked	11
-shouldve	11
 disturbed	11
 30m	11
 obstacles	11
@@ -13864,7 +13837,6 @@ balances	11
 Amsterdam	11
 Mavs	11
 reservations	11
-everyones	11
 notoriously	11
 zap	11
 flute	11
@@ -15198,7 +15170,6 @@ tender	9
 goto	9
 meaty	9
 hemp	9
-Lebrons	9
 dissolve	9
 gunning	9
 heavyweight	9
@@ -15864,7 +15835,6 @@ dispatch	9
 evenings	9
 wattage	9
 apostles	9
-theyve	9
 O.o	9
 skew	9
 Travis	9
@@ -16033,7 +16003,6 @@ TSA	9
 narcissists	9
 enact	9
 deprecating	9
-theyll	9
 Natalie	9
 unplug	9
 intern	9
@@ -16694,7 +16663,6 @@ detract	8
 journals	8
 stinks	8
 cooperative	8
-mens	8
 Fae	8
 Jaime	8
 snort	8
@@ -17222,7 +17190,6 @@ NH	8
 shortened	8
 redraft	8
 Majin	8
-yknow	8
 outgoing	8
 negated	8
 restraint	8
@@ -17450,7 +17417,6 @@ nickel	8
 scenery	8
 Gotenks	8
 Amethyst	8
-hows	8
 Gabriel	8
 Ultimates	8
 slark	8
@@ -18356,7 +18322,6 @@ Transformers	7
 Beware	7
 Ebony	7
 hegemonic	7
-childrens	7
 freshmen	7
 identification	7
 FTF	7
@@ -18400,7 +18365,6 @@ stutter	7
 regretted	7
 fireballs	7
 Thibs	7
-teh	7
 Vic	7
 grads	7
 mishandled	7
@@ -19212,7 +19176,6 @@ Belfast	7
 libtards	7
 Spectral	7
 jammed	7
-couldve	7
 GTI	7
 Pac	7
 Ovi	7
@@ -22045,7 +22008,6 @@ securely	5
 wicks	5
 slurpee	5
 powerspike	5
-didn	5
 Poloniex	5
 BCN	5
 goodest	5
@@ -22475,7 +22437,6 @@ DMCA	5
 slugger	5
 epsom	5
 Lather	5
-itd	5
 waaaay	5
 DPC	5
 Ojeleye	5
@@ -22838,7 +22799,6 @@ pupils	5
 bytecoin	5
 Heo	5
 arbiter	5
-isn	5
 Zell	5
 VIII	5
 pleasures	5

--- a/release/nrc/nrc.en.mtnt/source/mtnt.tsv
+++ b/release/nrc/nrc.en.mtnt/source/mtnt.tsv
@@ -3830,7 +3830,6 @@ recover	66
 rant	66
 entertainment	65
 motivation	65
-ツ	65
 aged	65
 halfway	65
 IV	65
@@ -5789,7 +5788,6 @@ requests	38
 procedure	38
 mechanism	38
 Republic	38
-͜	38
 museum	38
 socks	38
 chests	38
@@ -5922,7 +5920,6 @@ promising	37
 slap	37
 completing	37
 AAA	37
-ʖ	37
 holocaust	37
 cube	37
 Patriots	37
@@ -7094,7 +7091,6 @@ shore	29
 appearances	29
 vaguely	29
 sore	29
-™	29
 networking	29
 funded	29
 demographic	29
@@ -7145,7 +7141,6 @@ counted	29
 vault	29
 stickers	29
 absorb	29
-„	29
 legendaries	29
 Yui	29
 costume	29
@@ -8727,7 +8722,6 @@ Smalling	21
 believable	21
 incorporate	21
 deer	21
-»	21
 flaw	21
 reliant	21
 12th	21
@@ -9235,7 +9229,6 @@ settlement	20
 firmware	20
 sausage	20
 Mitch	20
-«	20
 Bayern	20
 dignity	20
 accountability	20
@@ -9510,7 +9503,6 @@ POC	19
 stfu	19
 cantrips	19
 textures	19
-√	19
 undoubtedly	19
 travels	19
 defensively	19
@@ -12509,7 +12501,6 @@ workload	13
 involuntary	13
 ohms	13
 autocorrect	13
-■	13
 breastfeeding	13
 goose	13
 warrants	13
@@ -14525,7 +14516,6 @@ NCAA	10
 depressive	10
 tally	10
 configure	10
-×	10
 hilariously	10
 robbing	10
 Jax	10
@@ -14790,7 +14780,6 @@ abnormal	10
 wardrobe	10
 disciples	10
 trailing	10
-▪	10
 moderates	10
 DUI	10
 intellectualism	10
@@ -14887,7 +14876,6 @@ Dolphin	10
 layered	10
 coloured	10
 banger	10
-―	10
 modders	10
 thickness	10
 neatly	10
@@ -15246,8 +15234,6 @@ arriving	9
 JL	9
 outliers	9
 sativa	9
-▢	9
-ಠ_ಠ	9
 Cheeto	9
 ninjas	9
 museums	9
@@ -16129,7 +16115,6 @@ toothpaste	9
 40s	9
 cuddle	9
 vibrant	9
-名	9
 adored	9
 uninformed	9
 Kindred	9
@@ -16188,7 +16173,6 @@ Rica	8
 zinc	8
 catastrophic	8
 Cisco	8
-，	8
 consented	8
 AMAs	8
 soloing	8
@@ -16467,7 +16451,6 @@ parroting	8
 mismatched	8
 tubs	8
 geography	8
-●	8
 superheroes	8
 adolescence	8
 stresses	8
@@ -16750,7 +16733,6 @@ contracted	8
 spinoff	8
 completes	8
 toons	8
-⏰	8
 goosebumps	8
 Eb	8
 tariff	8
@@ -16877,7 +16859,6 @@ forcibly	8
 designation	8
 skates	8
 PBMM	8
-₹	8
 nonstop	8
 suing	8
 Les	8
@@ -16927,7 +16908,6 @@ Crofty	8
 understatement	8
 collectibles	8
 convertible	8
-¥	8
 facet	8
 scholarly	8
 BIL	8
@@ -17715,7 +17695,6 @@ diced	7
 stamped	7
 Merkel	7
 weary	7
-®	7
 rotated	7
 halted	7
 sophomore	7
@@ -19093,7 +19072,6 @@ coastal	7
 TCW	7
 Disco	7
 Bubba	7
-道	7
 hamburger	7
 resorts	7
 unregulated	7
@@ -20676,7 +20654,6 @@ teleportation	6
 subwoofer	6
 towing	6
 thorns	6
-−	6
 fussy	6
 sensei	6
 banished	6
@@ -20769,7 +20746,6 @@ heed	6
 obedience	6
 midlaners	6
 amateurs	6
-之	6
 Miku	6
 visor	6
 flaming	6
@@ -21070,7 +21046,6 @@ peaking	6
 skit	6
 erode	6
 mog	6
-‽	6
 attends	6
 commissioned	6
 raft	6
@@ -22238,7 +22213,6 @@ ITB	5
 clapped	5
 Wilde	5
 graft	5
-无	5
 scammy	5
 sleazy	5
 Athena	5
@@ -22426,7 +22400,6 @@ liter	5
 Bjork	5
 Zellner	5
 waxed	5
-§	5
 Lacob	5
 categorically	5
 dud	5
@@ -23553,7 +23526,6 @@ seminars	5
 Sab	5
 Divines	5
 Daedra	5
-？	5
 Donnie	5
 YoYo	5
 FET	5

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -17,7 +17,7 @@
     <Name URL="">English language model mined from MTNT</Name>
     <Copyright URL="">© 2019-2021 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
-    <Version URL="">0.1.7</Version>
+    <Version URL="">0.1.8</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
Addresses some of #143 in cleaning up the following from the en.mtnt wordlist:
* typos of contractions
* teh
* symbols:
    * currencies
    * emojis
    * non-Latin characters
    * full-width punctuation

Items not addressed on this PR:
* usage of left-single quotation marks for contractions in the wordlist
* British spelling
* slang

