### PR TITLE
chore: Update lexical-model compiler to 16.0.138

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@keymanapp/lexical-model-compiler": "^15.0.263",
-        "@keymanapp/models-types": "^15.0.263",
+        "@keymanapp/lexical-model-compiler": "^16.0.138",
+        "@keymanapp/models-types": "^16.0.138",
         "@types/node": "^10.17.27",
         "node": "^14.15.0",
         "typescript": "^3.9.6"
@@ -21,14 +21,20 @@
         "xml2js": "^0.4.23"
       }
     },
+    "node_modules/@keymanapp/keyman-version": {
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-16.0.138.tgz",
+      "integrity": "sha512-N5gQvxZBJnsP+uPj4I9wZbmTF512YhE4Ov7sQ7W/slWvpoTPOtjZ8EU1AIrk99/t1IEUNqvb0Q9BeyckQtMI7g=="
+    },
     "node_modules/@keymanapp/lexical-model-compiler": {
-      "version": "15.0.263",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-15.0.263.tgz",
-      "integrity": "sha512-C7/vtdN2xJ2vKBSq68vr0hqNDG0hPsQ+fE3Vswzk7PUvT/pllRIyLLREhbbyahMLU6ZeLm4f7obiV2lKkL0/5g==",
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-16.0.138.tgz",
+      "integrity": "sha512-oVIWLJDXVR+PlJF3l13dQFseNZrM9ZqA6pGJ5yTCyg6O0IMe1PcQTW5Wy+4gNGbrYzQ59Jq/vhTX5znGUVjwRQ==",
       "dependencies": {
-        "@keymanapp/models-types": "^15.0.263",
+        "@keymanapp/keyman-version": "*",
+        "@keymanapp/models-types": "*",
         "commander": "^3.0.0",
-        "typescript": "^3.8.3",
+        "typescript": "^4.5.4",
         "xml2js": "^0.4.19"
       },
       "bin": {
@@ -37,13 +43,25 @@
         "kmlmp": "dist/kmlmp.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@keymanapp/lexical-model-compiler/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@keymanapp/models-types": {
-      "version": "15.0.263",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-15.0.263.tgz",
-      "integrity": "sha512-EFKMf6QedeR7E0Jf/LaV54wN6W7QsyHqTOL2dVI0NqiKh/G6++QEEMnsqHWGyA4qVFgqxVY1+wt55ZL/IdY8ig=="
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-16.0.138.tgz",
+      "integrity": "sha512-8pM6Eaxv+03wgJODTVJP190QB5Sjstg7v99yqPtYCyKNIHVAcUijMftuBALy/tnXddmDzqbSrx6YANXsxCfJnA=="
     },
     "node_modules/@types/node": {
       "version": "10.17.27",
@@ -284,21 +302,34 @@
     }
   },
   "dependencies": {
+    "@keymanapp/keyman-version": {
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/keyman-version/-/keyman-version-16.0.138.tgz",
+      "integrity": "sha512-N5gQvxZBJnsP+uPj4I9wZbmTF512YhE4Ov7sQ7W/slWvpoTPOtjZ8EU1AIrk99/t1IEUNqvb0Q9BeyckQtMI7g=="
+    },
     "@keymanapp/lexical-model-compiler": {
-      "version": "15.0.263",
-      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-15.0.263.tgz",
-      "integrity": "sha512-C7/vtdN2xJ2vKBSq68vr0hqNDG0hPsQ+fE3Vswzk7PUvT/pllRIyLLREhbbyahMLU6ZeLm4f7obiV2lKkL0/5g==",
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-16.0.138.tgz",
+      "integrity": "sha512-oVIWLJDXVR+PlJF3l13dQFseNZrM9ZqA6pGJ5yTCyg6O0IMe1PcQTW5Wy+4gNGbrYzQ59Jq/vhTX5znGUVjwRQ==",
       "requires": {
-        "@keymanapp/models-types": "^15.0.263",
+        "@keymanapp/keyman-version": "*",
+        "@keymanapp/models-types": "*",
         "commander": "^3.0.0",
-        "typescript": "^3.8.3",
+        "typescript": "^4.5.4",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+        }
       }
     },
     "@keymanapp/models-types": {
-      "version": "15.0.263",
-      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-15.0.263.tgz",
-      "integrity": "sha512-EFKMf6QedeR7E0Jf/LaV54wN6W7QsyHqTOL2dVI0NqiKh/G6++QEEMnsqHWGyA4qVFgqxVY1+wt55ZL/IdY8ig=="
+      "version": "16.0.138",
+      "resolved": "https://registry.npmjs.org/@keymanapp/models-types/-/models-types-16.0.138.tgz",
+      "integrity": "sha512-8pM6Eaxv+03wgJODTVJP190QB5Sjstg7v99yqPtYCyKNIHVAcUijMftuBALy/tnXddmDzqbSrx6YANXsxCfJnA=="
     },
     "@types/node": {
       "version": "10.17.27",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
-    "@keymanapp/lexical-model-compiler": "^15.0.263",
-    "@keymanapp/models-types": "^15.0.263",
+    "@keymanapp/lexical-model-compiler": "^16.0.138",
+    "@keymanapp/models-types": "^16.0.138",
     "@types/node": "^10.17.27",
     "node": "^14.15.0",
     "typescript": "^3.9.6"


### PR DESCRIPTION
Accompanying the Keyman 16.0.138 release, this updates the lexical-model compiler from 15.0 to 16.0

There's a multititude of compiler warnings
* duplicate words found in a (wordlist) file; summing counts
* entries not being Unicode NFC. Automatically converting to NFC

But the overall build passes

I note node is still  `"^14.15.0",` which we should update to LTS at some point.