### PR TITLE
chore: Rebuild to use ES3 code generation

### DIFF
--- a/release/dotland/dotland.ru.russian/HISTORY.md
+++ b/release/dotland/dotland.ru.russian/HISTORY.md
@@ -1,6 +1,14 @@
 Russian Change History
 ====================
 
+1.3 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
+1.2 (2022-08-01)
+----------------
+* Reduced wordlist to 76,000 for better performance
+
 1.0 (2022-07-09)
 ----------------
 * Created by Tigran Sarukhanyan

--- a/release/dotland/dotland.ru.russian/source/dotland.ru.russian.model.kps
+++ b/release/dotland/dotland.ru.russian/source/dotland.ru.russian.model.kps
@@ -17,9 +17,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Russian</Name>
-    <Copyright URL="">© Dotland</Copyright>
+    <Copyright URL="">© 2022-2023 Dotland</Copyright>
     <Author URL="mailto:tisarukhan@gmail.com">Tigran Sarukhanyan</Author>
-    <Version URL="">1.2</Version>
+    <Version URL="">1.3</Version>
     <WebSite URL="https://github.com/dotland/mnemonic-kb-ru/blob/main/README.md">https://github.com/dotland/mnemonic-kb-ru/blob/main/README.md</WebSite>
   </Info>
   <Files>

--- a/release/iles/iles.chp.indigenous_nt/HISTORY.md
+++ b/release/iles/iles.chp.indigenous_nt/HISTORY.md
@@ -1,6 +1,10 @@
 Indigenous NT Change History
 ====================
 
+0.2 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 0.1 (2021-12-01)
 ----------------
 * Created from 30,000 preliminary word list derived from Lutselke Dictionary

--- a/release/iles/iles.chp.indigenous_nt/source/iles.chp.indigenous_nt.model.kps
+++ b/release/iles/iles.chp.indigenous_nt/source/iles.chp.indigenous_nt.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Indigenous NT</Name>
-    <Copyright URL="">© 2021 ILES</Copyright>
+    <Copyright URL="">© 2021-2023 ILES</Copyright>
     <Author URL="">ILES</Author>
-    <Version URL="">0.1</Version>
+    <Version URL="">0.2</Version>
   </Info>
   <Files>
     <File>

--- a/release/iles/iles.dgr.indigenous_nt/HISTORY.md
+++ b/release/iles/iles.dgr.indigenous_nt/HISTORY.md
@@ -1,6 +1,10 @@
 Indigenous NT Change History
 ====================
 
+0.2 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 0.1 (2021-06-09)
 ----------------
 * Created and tested from 30,000 preliminary word list

--- a/release/iles/iles.dgr.indigenous_nt/source/iles.dgr.indigenous_nt.model.kps
+++ b/release/iles/iles.dgr.indigenous_nt/source/iles.dgr.indigenous_nt.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Indigenous NT</Name>
-    <Copyright URL="">© 2021 ILES</Copyright>
+    <Copyright URL="">© 2021-2023 ILES</Copyright>
     <Author URL="">ILES</Author>
-    <Version URL="">0.1</Version>
+    <Version URL="">0.2</Version>
   </Info>
   <Files>
     <File>

--- a/release/nrc/nrc.str.sencoten/HISTORY.md
+++ b/release/nrc/nrc.str.sencoten/HISTORY.md
@@ -1,25 +1,29 @@
 # Version History
 
-## 1.0.5
+1.0.6 (2023-03-21)
+------------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
 
+1.0.5 (2023-03-07)
+------------------
 * Clean up versioning in .kps package file
 
-## 1.0.4
-
+1.0.4 (2019-11-28)
+------------------
 * Fix copyright (#59)
 
-## 1.0.3
-
+1.0.3 (2019-10-07)
+------------------
 * Add the common word "ȻNES" (#46)
 
-## 1.0.2
-
+1.0.2 (2019-06-20)
+------------------
 * Simplify model name to "dictionary" (#43)
 
-## 1.0.1
-
+1.0.1 (2019-06-12)
+------------------
 * Cleaned up duplicate entries (#41)
 
-## 1.0.0
-
+1.0.0 (2019-06-05)
+------------------
 * Initial release (#40)

--- a/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
@@ -8,9 +8,9 @@
   </Options>
   <Info>
     <Name URL="">SENĆOŦEN (Saanich Dialect) Lexical Model</Name>
-    <Copyright URL="">© 2019 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
+    <Copyright URL="">© 2019-2023 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.bcc-arab.upp_ptwl1/HISTORY.md
+++ b/release/sil/sil.bcc-arab.upp_ptwl1/HISTORY.md
@@ -1,6 +1,10 @@
 Balochi Change History
 ======================
 
+1.2.2 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 1.2.1 (2022-02-18)
 ----------------
 Work only with composed forms.

--- a/release/sil/sil.bcc-arab.upp_ptwl1/source/sil.bcc-arab.upp_ptwl1.model.kps
+++ b/release/sil/sil.bcc-arab.upp_ptwl1/source/sil.bcc-arab.upp_ptwl1.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Balochi</Name>
-    <Copyright URL="">© 2020-2022 SIL International</Copyright>
+    <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">SIL International</Author>
-    <Version URL="">1.2.1</Version>
+    <Version URL="">1.2.2</Version>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.glk-arab.ptwl1/HISTORY.md
+++ b/release/sil/sil.glk-arab.ptwl1/HISTORY.md
@@ -1,6 +1,10 @@
 ptwl1 Change History
 ====================
 
+1.0.6 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 1.0.5 (2022-08-31)
 ------------------
 add glk to list of BCP 47 codes

--- a/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
+++ b/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">ptwl1</Name>
-    <Copyright URL="">© 2020-2022 SIL International</Copyright>
+    <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">RL</Author>
-    <Version URL="">1.0.5</Version>
+    <Version URL="">1.0.6</Version>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.kjg-laoo.ptwl1/HISTORY.md
+++ b/release/sil/sil.kjg-laoo.ptwl1/HISTORY.md
@@ -1,6 +1,10 @@
 ptwl1 Change History
 ====================
 
+1.1 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 1.0 (2020-06-01)
 ----------------
 * Created by SIL International

--- a/release/sil/sil.kjg-laoo.ptwl1/source/sil.kjg-laoo.ptwl1.model.kps
+++ b/release/sil/sil.kjg-laoo.ptwl1/source/sil.kjg-laoo.ptwl1.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">ptwl1</Name>
-    <Copyright URL="">© 2020 SIL International</Copyright>
+    <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">SIL International</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.1</Version>
   </Info>
   <Files>
     <File>

--- a/release/wyc_eth/wyc_eth.mym-latn.me_en/HISTORY.md
+++ b/release/wyc_eth/wyc_eth.mym-latn.me_en/HISTORY.md
@@ -1,5 +1,10 @@
 Me'en Change History
 ====================
+
+1.2 (2023-03-21)
+----------------
+* Rebuilt with ES3 code generation to support Android 5.0 devices
+
 1.1 (2020-03-27)
 * Eliminate automatic space after selected word, since users often add suffixes or punctuation after a word
 

--- a/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.kps
+++ b/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Me'en</Name>
-    <Copyright URL="">© 2020 Wycliffe Ethiopia</Copyright>
+    <Copyright URL="">© 2020-2023 Wycliffe Ethiopia</Copyright>
     <Author URL="">Wycliffe Ethiopia</Author>
-    <Version URL="">1.1</Version>
+    <Version URL="">1.2</Version>
   </Info>
   <Files>
     <File>


### PR DESCRIPTION
Fixes #182 

Now that the lexical-models repo is using 16.0.138 stable of the lexical-model compiler, this PR bumps the version for the listed models in the issue. This forces ES3 code generation to support Android 5.0 devices.

Also updates nrc.str.sencoten
