### PR TITLE
fix: updates example.en.custom

### DIFF
--- a/sample/example/example.en.custom/source/predict.ts
+++ b/sample/example/example.en.custom/source/predict.ts
@@ -1,25 +1,27 @@
-/// <reference path="../../../../includes/LMLayerWorker.d.ts" />
+/// <reference types="@keymanapp/models-types" />
 
 /*
   Example custom-class predictor for the en.custom model
 */
-class ExampleCustom implements WorkerInternalModel {
+class ExampleCustom implements LexicalModel {
   configuration: Configuration;
 
   configure(capabilities: Capabilities) {
     return this.configuration = {
-      leftContextCodeUnits: 64 < capabilities.maxLeftContextCodeUnits ? 64 : capabilities.maxLeftContextCodeUnits,
-      rightContextCodeUnits: 0
+      leftContextCodePoints: 64 < capabilities.maxLeftContextCodePoints ? 64 : capabilities.maxLeftContextCodePoints,
+      rightContextCodePoints: 0
     }
   }
 
-  // TODO:  Needs to reference a .d.ts file for type definitions!
-  predict(transform: Transform, context: Context): Suggestion[] {
+  predict(transform: Transform, context: Context): Distribution<Suggestion> {
     if(context.left == 'f') {
-      return [{transform: {
+      return [{
+        sample: {transform: {
           deleteLeft: 1,
           insert: 'foo'
-        }, displayAs: 'foo'}];
+        }, displayAs: 'foo'},
+        p: 1.0
+      }];
     } else {
       return [];
     }

--- a/sample/example/example.en.custom_word_breaker/source/example.en.custom_word_breaker.model.ts
+++ b/sample/example/example.en.custom_word_breaker/source/example.en.custom_word_breaker.model.ts
@@ -1,4 +1,5 @@
-/// <reference types="@keymanapp/lexical-model-types" />
+// Defines LexicalModelSource.
+/// <reference types="@keymanapp/lexical-model-compiler/dist/kmlmc.d.ts" />
 
 const source: LexicalModelSource = {
   format: 'trie-1.0',


### PR DESCRIPTION
We hadn't exactly maintained the custom model for a while, so this should update it to working order.  I even tested it in KMW by temporarily linking it with one of the testing pages:

![image](https://github.com/keymanapp/lexical-models/assets/25213402/013e19fc-45b2-42d3-896d-0cb5d950ea8a)

The scary thing is... it actually _did_ compile before this, despite some of the referenced types not actually existing.  I went ahead and made sure that all types currently referenced do exist.