### PR TITLE
GFF Tigrinya-Ethiopia Lexical Model v1.0.1

### DIFF
--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.kpj
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.kpj
@@ -19,7 +19,7 @@
       <ID>id_1499e91aec3343ff3062111dac598b4f</ID>
       <Filename>gff.ti_er.gff_tigrinya_eritreaa.model.kps</Filename>
       <Filepath>source\gff.ti_er.gff_tigrinya_eritreaa.model.kps</Filepath>
-      <FileVersion>1.2</FileVersion>
+      <FileVersion></FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Tigrinya-Eritrean Lexical Model</Name>
@@ -58,7 +58,7 @@
     <File>
       <ID>id_62b717a096229fd4972faf20cdc8f95b</ID>
       <Filename>gff.ti_er.gff_tigrinya_eritreaa.model.js</Filename>
-      <Filepath>source\..\build\gff.ti_er.gff_tigrinya_eritreaa.model.js</Filepath>
+      <Filepath>build\gff.ti_er.gff_tigrinya_eritreaa.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
       <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/HISTORY.md
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/HISTORY.md
@@ -1,6 +1,12 @@
 GFF Tigrinya-Ethiopian Lexical Model Change History
 ===================================================
 
+1.0.1 (2023-07-08)
+------------------
+* Display name fix and readme.htm, and welcome.htm enhancement.
+* `.kpj` typo fix for resource version number.
+* Deprecation added for the region-neutral Tigrinya dictionary.
+
 1.0 (2023-06-17)
 ----------------
 * Initial release based on a Wegahit newspaper corpus.

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/README.md
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/README.md
@@ -1,5 +1,5 @@
 GFF Tigrinya-Ethiopian Lexical Model
-==========================
+====================================
 
 © 2023 Geʾez Frontier Foundation
 
@@ -33,4 +33,3 @@ Supported Platforms
  * Mobile devices
  * Desktop devices
  * Tablet devices
-

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/gff.ti_et.gff_tigrinya_ethiopia.kpj
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/gff.ti_et.gff_tigrinya_ethiopia.kpj
@@ -16,15 +16,15 @@
       <FileType>.ts</FileType>
     </File>
     <File>
-      <ID>id_1499e91aec3343ff3062111dac598b4f</ID>
+      <ID>id_03ece69616e6ef0388964b5843fce535</ID>
       <Filename>gff.ti_et.gff_tigrinya_ethiopia.model.kps</Filename>
       <Filepath>source\gff.ti_et.gff_tigrinya_ethiopia.model.kps</Filepath>
-      <FileVersion>1.2</FileVersion>
+      <FileVersion>1.0.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
-        <Name>GFF Tigrinya Ethiopia Lexical Model</Name>
+        <Name>GFF Tigrinya-Ethiopia Lexical Model</Name>
         <Copyright>© 2023 Geʾez Frontier Foundation</Copyright>
-        <Version>1.2</Version>
+        <Version>1.0.1</Version>
       </Details>
     </File>
     <File>
@@ -56,12 +56,12 @@
       <FileType>.model_info</FileType>
     </File>
     <File>
-      <ID>id_62b717a096229fd4972faf20cdc8f95b</ID>
+      <ID>id_bd5d0f5db6e7d5d6bb9d0a5dd93151f0</ID>
       <Filename>gff.ti_et.gff_tigrinya_ethiopia.model.js</Filename>
       <Filepath>source\..\build\gff.ti_et.gff_tigrinya_ethiopia.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_03ece69616e6ef0388964b5843fce535</ParentFileID>
     </File>
     <File>
       <ID>id_356e5d149c1e539356d72698c1e401a6</ID>
@@ -69,7 +69,7 @@
       <Filepath>source\welcome.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_03ece69616e6ef0388964b5843fce535</ParentFileID>
     </File>
     <File>
       <ID>id_8da344c4cea6f467013357fe099006f5</ID>
@@ -77,7 +77,7 @@
       <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_03ece69616e6ef0388964b5843fce535</ParentFileID>
     </File>
   </Files>
 </KeymanDeveloperProject>

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/gff.ti_et.gff_tigrinya_ethiopia.model_info
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/gff.ti_et.gff_tigrinya_ethiopia.model_info
@@ -3,5 +3,10 @@
     "languages": [
         "ti-ET"
     ],
-	"description": "The Tigrinya-Ethiopia lexical model is based on the content found from 100 issues of the Wegahta (ወጋሕታ) newspaper."
+	"description": "The Tigrinya-Ethiopia lexical model is based on the content found from 100 issues of the Wegahta (ወጋሕታ) newspaper.",
+	 "related": {
+	   "gff.ti.gff_tigrinya": {
+        "deprecates": true
+       }
+    }
 }

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/gff.ti_et.gff_tigrinya_ethiopia.model.kps
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/gff.ti_et.gff_tigrinya_ethiopia.model.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.104.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
@@ -18,7 +18,7 @@
     <Name URL="">GFF Tigrinya-Ethiopia Lexical Model</Name>
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.0.1</Version>
   </Info>
   <Files>
     <File>
@@ -43,7 +43,7 @@
   <Keyboards/>
   <LexicalModels>
     <LexicalModel>
-      <Name></Name>
+      <Name>GFF Ethiopian Tigrinya</Name>
       <ID>gff.ti_et.gff_tigrinya_ethiopia</ID>
       <Languages>
         <Language ID="ti-ET">Tigrinya (Ethiopia)</Language>

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/readme.htm
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/readme.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Tigrinya Lexical Model</title>
+  <title>GFF Tigrinya-Ethiopian Lexical Model</title>
   <style type="text/css">
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<h1>Tigrinya Lexical Model</h1>
+<h1>GFF Tigrinya-Ethiopian Lexical Model</h1>
 
 <p>
 This is a Tigrinya (ትግርኛ , ISO-639-2 ti-ET) lexical model developed to support predictive text in 
@@ -24,11 +24,10 @@ future version of the lexical model.
 
 <h2>Links</h2>
 <ul>
-  <li>UniLex TI Word List: <a href="https://github.com/unicode-org/unilex/blob/master/data/frequency/ti.txt">https://github.com/unicode-org/unilex/blob/master/data/frequency/ti.txt</a></li>
+  <li>Weghata (ወጋሕታ): <a href="https://press.et/wegahta/">https://press.et/wegahta/</a>
 </ul>
 
-
-<p>© 2020 – 2023 Geʾez Frontier Foundation</p>
+<p>© 2023 Geʾez Frontier Foundation</p>
 
 </body>
 </html>

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/welcome.htm
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/welcome.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Start Using GFF Tigrinya</title>
+  <title>GFF Tigrinya-Ethiopia Lexical Model</title>
   <style type="text/css">
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
@@ -11,18 +11,19 @@
 </head>
 <body>
 
-<h1>Start Using GFF Tigrinya</h1>
+<h1>GFF Tigrinya-Ethiopian Lexical Model</h1>
 
 <p>
-    This lexical model is intended for use with the Tigrinya Keyman Keyboard on mobile devices, see:
-    <a href="https://keyman.com/tigrigna/">https://keyman.com/tigrigna/</a>
+This lexical model is intended for use with the Tigrinya-Ethiopian Keyman Keyboard on mobile devices, see:
+<a href="https://keyman.com/keyboards/gff_tigrinya_ethiopia">https://keyman.com/keyboards/gff_tigrinya_ethiopia/</a>
 </p>
 
-<!-- h1>Wordlist Model Documentation</h1 -->
+<p>
+Please report any problems by creating an issue ticket at the project's GitHub repository: 
+<a href="https://github.com/keymanapp/lexical-models/issues">https://github.com/keymanapp/lexical-models/issues</a>
+</p>
 
-<!-- Insert HTML documentation here -->
-
-<p>© 2020 – 2023 Geʾez Frontier Foundation</p>
+<p>© 2023 Geʾez Frontier Foundation</p>
 
 </body>
 </html>


### PR DESCRIPTION
This update fixes some minor but important issues:

* The dictionary display name (&lt;LexicalModel&gt;&lt;Name&gt;) is now populated.
* The `.model_info` file deprecates the region-neutral Tigrinya lexical model.
* `readme.htm` is in synch with the `README.md`
* `welcome.htm` is enhanced.
* Some resource versions (1.2) which were held over from the region-neutral `.kpj` file have been set properly.

Note that the wordlist is unchanged.  The `.kmp` file has been manually installed on an Android phone and verified.