### PR TITLE
GFF Tigrinya-Eritrea Lexical Model v1.0.1

### DIFF
--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/HISTORY.md
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/HISTORY.md
@@ -1,6 +1,12 @@
 GFF Tigrinya-Eritrean Lexical Change History
 ============================================
 
+1.0.1 (2023-07-08)
+------------------
+* Display name fix and readme.htm enhancement.
+* `.kpj` typo fix to allow `.kps` file to be built.
+* Deprecation added for the region-neutral Tigrinya dictionary.
+
 1.0 (2023-06-18)
 ----------------
 * Initial release based on a Haddas Eritrea corpus.

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/HISTORY.md
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/HISTORY.md
@@ -1,9 +1,9 @@
-GFF Tigrinya-Eritrean Lexical Change History
-============================================
+GFF Tigrinya-Eritrean Lexical Model Change History
+==================================================
 
 1.0.1 (2023-07-08)
 ------------------
-* Display name fix and readme.htm enhancement.
+* Display name fix and readme.htm, and welcome.htm enhancement.
 * `.kpj` typo fix to allow `.kps` file to be built.
 * Deprecation added for the region-neutral Tigrinya dictionary.
 

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/README.md
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/README.md
@@ -3,7 +3,7 @@ GFF Tigrinya-Eritrean Lexical Model
 
 © 2023 Geʾez Frontier Foundation
 
-Version 1.0
+Version 1.0.1
 
 Description
 -----------

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.kpj
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.kpj
@@ -10,21 +10,21 @@
   <Files>
     <File>
       <ID>id_71ec81e779cf48d6f4711907a19624e0</ID>
-      <Filename>gff.ti_er.gff_tigrinya_eritreaa.model.ts</Filename>
-      <Filepath>source\gff.ti_er.gff_tigrinya_eritreaa.model.ts</Filepath>
+      <Filename>gff.ti_er.gff_tigrinya_eritrea.model.ts</Filename>
+      <Filepath>source\gff.ti_er.gff_tigrinya_eritrea.model.ts</Filepath>
       <FileVersion>1.0</FileVersion>
       <FileType>.ts</FileType>
     </File>
     <File>
-      <ID>id_1499e91aec3343ff3062111dac598b4f</ID>
-      <Filename>gff.ti_er.gff_tigrinya_eritreaa.model.kps</Filename>
-      <Filepath>source\gff.ti_er.gff_tigrinya_eritreaa.model.kps</Filepath>
-      <FileVersion>1.2</FileVersion>
+      <ID>id_c7dafbe8e90af04f4d6b841f1dde97b3</ID>
+      <Filename>gff.ti_er.gff_tigrinya_eritrea.model.kps</Filename>
+      <Filepath>source\gff.ti_er.gff_tigrinya_eritrea.model.kps</Filepath>
+      <FileVersion>1.0.1</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>GFF Tigrinya-Eritrean Lexical Model</Name>
         <Copyright>© 2023 Geʾez Frontier Foundation</Copyright>
-        <Version>1.0</Version>
+        <Version>1.0.1</Version>
       </Details>
     </File>
     <File>
@@ -50,18 +50,18 @@
     </File>
     <File>
       <ID>id_3dcb4ba398ce2936f9d1a37641d300b9</ID>
-      <Filename>gff.ti_er.gff_tigrinya_eritreaa.model_info</Filename>
-      <Filepath>gff.ti_er.gff_tigrinya_eritreaa.model_info</Filepath>
+      <Filename>gff.ti_er.gff_tigrinya_eritrea.model_info</Filename>
+      <Filepath>gff.ti_er.gff_tigrinya_eritrea.model_info</Filepath>
       <FileVersion></FileVersion>
       <FileType>.model_info</FileType>
     </File>
     <File>
-      <ID>id_62b717a096229fd4972faf20cdc8f95b</ID>
-      <Filename>gff.ti_er.gff_tigrinya_eritreaa.model.js</Filename>
-      <Filepath>source\..\build\gff.ti_er.gff_tigrinya_eritreaa.model.js</Filepath>
+      <ID>id_a7f372e95aec49d25fd9f412b5d2e439</ID>
+      <Filename>gff.ti_er.gff_tigrinya_eritrea.model.js</Filename>
+      <Filepath>source\..\build\gff.ti_er.gff_tigrinya_eritrea.model.js</Filepath>
       <FileVersion></FileVersion>
       <FileType>.js</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_c7dafbe8e90af04f4d6b841f1dde97b3</ParentFileID>
     </File>
     <File>
       <ID>id_356e5d149c1e539356d72698c1e401a6</ID>
@@ -69,7 +69,7 @@
       <Filepath>source\welcome.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_c7dafbe8e90af04f4d6b841f1dde97b3</ParentFileID>
     </File>
     <File>
       <ID>id_8da344c4cea6f467013357fe099006f5</ID>
@@ -77,7 +77,7 @@
       <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
-      <ParentFileID>id_1499e91aec3343ff3062111dac598b4f</ParentFileID>
+      <ParentFileID>id_c7dafbe8e90af04f4d6b841f1dde97b3</ParentFileID>
     </File>
   </Files>
 </KeymanDeveloperProject>

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.model_info
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/gff.ti_er.gff_tigrinya_eritrea.model_info
@@ -3,5 +3,10 @@
     "languages": [
         "ti-ER"
     ],
-	  "description": "The Tigrinya-Eritrea lexical model is based on the content found from 131 issues of the Haddas Eritrea (ሓዳስ ኤርትራ) newspaper."
+	 "description": "The Tigrinya-Eritrea lexical model is based on the content found from 131 issues of the Haddas Eritrea (ሓዳስ ኤርትራ) newspaper.",
+	 "related": {
+	   "gff.ti.gff_tigrinya": {
+        "deprecates": true
+       }
+    }
 }

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/gff.ti_er.gff_tigrinya_eritrea.model.kps
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/gff.ti_er.gff_tigrinya_eritrea.model.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>13.0.104.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>16.0.139.0</KeymanDeveloperVersion>
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">GFF Tigrinya-Eritrean Lexical Model</Name>
-    <Copyright URL="">© 2020 - 2023 Geʾez Frontier Foundation</Copyright>
+    <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
-    <Version URL="">1.0</Version>
+    <Version URL="">1.0.1</Version>
   </Info>
   <Files>
     <File>
@@ -43,7 +43,7 @@
   <Keyboards/>
   <LexicalModels>
     <LexicalModel>
-      <Name></Name>
+      <Name>GFF Eritrean Tigrinya</Name>
       <ID>gff.ti_er.gff_tigrinya_eritrea</ID>
       <Languages>
         <Language ID="ti-ER">Tigrinya (Eritrea)</Language>

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/readme.htm
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/readme.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Tigrinya Lexical Model</title>
+  <title>GFF Tigrinya-Eritrean Lexical Model</title>
   <style type="text/css">
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<h1>Tigrinya Lexical Model</h1>
+<h1>GFF Tigrinya-Eritrean Lexical Model</h1>
 
 <p>
 This is a Tigrinya (ትግርኛ , ISO-639-2 ti-ER) lexical model developed to support predictive text in 

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/readme.htm
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/readme.htm
@@ -14,22 +14,20 @@
 <h1>Tigrinya Lexical Model</h1>
 
 <p>
-This is a Tigrinya (ትግርኛ , ISO-639-2 ti) lexical model developed to support predictive text in 
-corresponding GFF Tigrinya keyboards.  The lexical model relies on the UniLex projects's word
-List for Tigrinya.  The word list has been modified to remove English entries only.  The word
-list has not otherwise been reviewed to validate spelling or separate Eritrean Tigrinya from
-Ethiopian Tigrinya spelling conventions. These refinements are goals to be addressed in the
-future development of this lexical model.
+This is a Tigrinya (ትግርኛ , ISO-639-2 ti-ER) lexical model developed to support predictive text in 
+the corresponding GFF Tigrinya-Eritrea keyboard.  The lexical model is based on the content found from 131
+issues of the Haddas Eritrea (ሓዳስ ኤርትራ) newspaper. English words have been removed from the generated word list,
+but quality checks for spelling, etc. have not been performed.  These checks are left as a goal for a
+future version of the lexical model.
 </p>
 
 
 <h2>Links</h2>
 <ul>
-  <li>UniLex TI Word List: <a href="https://github.com/unicode-org/unilex/blob/master/data/frequency/ti.txt">https://github.com/unicode-org/unilex/blob/master/data/frequency/ti.txt</a></li>
+  <li>Haddas Eritrea (ሓዳስ ኤርትራ): <a href="https://shabait.com/category/newspapers/haddas-ertra-news/">https://shabait.com/category/newspapers/haddas-ertra-news/</a>
 </ul>
 
-
-<p>© 2020 – 2023 Geʾez Frontier Foundation</p>
+<p>© 2023 Geʾez Frontier Foundation</p>
 
 </body>
 </html>

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/welcome.htm
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/welcome.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Start Using GFF Tigrinya</title>
+  <title>GFF Tigrinya-Eritrean Lexical Model</title>
   <style type="text/css">
     p { font: 10pt Tahoma; }
     h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
@@ -11,18 +11,19 @@
 </head>
 <body>
 
-<h1>Start Using GFF Tigrinya</h1>
+<h1>GFF Tigrinya-Eritrean Lexical Model</h1>
 
 <p>
-    This lexical model is intended for use with the Tigrinya Keyman Keyboard on mobile devices, see:
-    <a href="https://keyman.com/tigrigna/">https://keyman.com/tigrigna/</a>
+This lexical model is intended for use with the Tigrinya-Eritrean Keyman Keyboard on mobile devices, see:
+<a href="https://keyman.com/keyboards/gff_tigrinya_eritrea">https://keyman.com/keyboards/gff_tigrinya_eritrea/</a>
 </p>
 
-<!-- h1>Wordlist Model Documentation</h1 -->
+<p>
+Please report any problems by creating an issue ticket at the project's GitHub repository: 
+<a href="https://github.com/keymanapp/lexical-models/issues">https://github.com/keymanapp/lexical-models/issues</a>
+</p>
 
-<!-- Insert HTML documentation here -->
-
-<p>© 2020 – 2023 Geʾez Frontier Foundation</p>
+<p>© 2023 Geʾez Frontier Foundation</p>
 
 </body>
 </html>


### PR DESCRIPTION
This update fixes some minor but important issues:

* The dictionary display name (&lt;LexicalModel&gt;&lt;Name&gt;) is now populated.
* The `.model_info` file deprecates the region-neutral Tigrinya lexical model.
* `readme.htm` is in synch with the `README.md`
* `welcome.htm` is enhanced.
* Some resource versions (1.2) which were held over from the region-neutral `.kpj` file have been set properly.
* A typo in the `.kpj` that mis-referenced the corresponding `.kps` file, blocking its compilation from the `.kpj` file, has been fixed.

Note that the wordlist is unchanged.  The `.kmp` file has been manually installed on an Android phone and verified.