### PR TITLE
[sapradhan.new-newa.nepal_bhasa] update wordlist

### DIFF
--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/HISTORY.md
@@ -1,5 +1,8 @@
-nepal-bhasa Change History
+# nepal-bhasa Change History
 ====================
+2.3 (2023-09-28)
+* Replaced 𑐫𑑂 (without zwj) with  𑐫𑑂‌ (with zwj)
+
 2.2 (2020-11-05)
 * Rebuild with lexical-model compiler using node 14.15.0
 
@@ -13,3 +16,4 @@ nepal-bhasa Change History
 1.0 (2020-03-07)
 ----------------
 * First compilation - ~21k words
+

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/LICENSE.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-(c) 2020 Ananda K Maharjan, Santosh Pradhan
+(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/README.md
@@ -1,29 +1,25 @@
-nepal-bhasa lexical model
-===================
+# nepal-bhasa lexical model
 
-(c) 2020 Ananda K Maharjan, Santosh Pradhan
+(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan
 
-Version 2.2
+Version 2.3
 
-Description
------------
+## Description
 
 Based on articles from nepalbhasatimes.com converted to Prachalit using https://www.hamroschool.com/a.php
 
-Links
------
+## Links
 
-Supported Platforms
--------------------
- * Windows
- * macOS
- * Linux
- * Web
- * iPhone
- * iPad
- * Android phone
- * Android tablet
- * Mobile devices
- * Desktop devices
- * Tablet devices
+## Supported Platforms
 
+- Windows
+- macOS
+- Linux
+- Web
+- iPhone
+- iPad
+- Android phone
+- Android tablet
+- Mobile devices
+- Desktop devices
+- Tablet devices

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/sapradhan.new-newa.nepal_bhasa.kpj
@@ -19,12 +19,12 @@
       <ID>id_762b4e980ddd27ac947ecb21fcc36e28</ID>
       <Filename>sapradhan.new-newa.nepal_bhasa.model.kps</Filename>
       <Filepath>source\sapradhan.new-newa.nepal_bhasa.model.kps</Filepath>
-      <FileVersion>2.2</FileVersion>
+      <FileVersion>2.3</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>nepal-bhasa</Name>
-        <Copyright>(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
-        <Version>2.2</Version>
+        <Copyright>(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan</Copyright>
+        <Version>2.3</Version>
       </Details>
     </File>
     <File>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/readme.htm
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/readme.htm
@@ -1,23 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>nepal-bhasa</title>
-  <style type="text/css">
-    p { font: 10pt Tahoma; }
-    h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
-    h2 { font: bold 12pt Tahoma; color: #4444cc; }
-  </style>
-</head>
-<body>
+  <head>
+    <meta charset="utf-8" />
+    <title>nepal-bhasa</title>
+    <style type="text/css">
+      p {
+        font: 10pt Tahoma;
+      }
+      h1 {
+        font: bold 16pt Tahoma;
+        color: #4444cc;
+        margin-bottom: 2px;
+      }
+      h2 {
+        font: bold 12pt Tahoma;
+        color: #4444cc;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>nepal-bhasa</h1>
 
-<h1>nepal-bhasa</h1>
+    <p>Contains Nepal Bhasa words in Newa script.</p>
 
-<p>
-    Contains Nepal Bhasa words in Newa script.
-</p>
-
-<p>(c) 2020 Ananda K Maharjan, Santosh Pradhan</p>
-
-</body>
+    <p>(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan</p>
+  </body>
 </html>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
@@ -16,9 +16,9 @@
   </StartMenu>
   <Info>
     <Name URL="">nepal-bhasa</Name>
-    <Copyright URL="">(c) 2020 Ananda K Maharjan, Santosh Pradhan</Copyright>
+    <Copyright URL="">(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan</Copyright>
     <Author URL="">Santosh Pradhan</Author>
-    <Version URL="">2.2</Version>
+    <Version URL="">2.3</Version>
   </Info>
   <Files>
     <File>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/welcome.htm
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/welcome.htm
@@ -1,27 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Start Using nepal-bhasa</title>
-  <style type="text/css">
-    p { font: 10pt Tahoma; }
-    h1 { font: bold 16pt Tahoma; color: #4444cc; margin-bottom: 2px }
-    h2 { font: bold 12pt Tahoma; color: #4444cc; }
-  </style>
-</head>
-<body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Start Using nepal-bhasa</title>
+    <style type="text/css">
+      p {
+        font: 10pt Tahoma;
+      }
+      h1 {
+        font: bold 16pt Tahoma;
+        color: #4444cc;
+        margin-bottom: 2px;
+      }
+      h2 {
+        font: bold 12pt Tahoma;
+        color: #4444cc;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Start Using nepal-bhasa</h1>
 
-<h1>Start Using nepal-bhasa</h1>
+    <p>Nepal Bhasa wordlist in Prachalit script</p>
 
-<p>
-    Nepal Bhasa wordlist in Prachalit script
-</p>
+    <h1>Wordlist Model Documentation</h1>
 
-<h1>Wordlist Model Documentation</h1>
+    Based on articles from nepalbhasatimes.com converted to Prachalit using
+    https://www.hamroschool.com/a.php
 
-Based on articles from nepalbhasatimes.com converted to Prachalit using https://www.hamroschool.com/a.php
-
-<p>(c) 2020 Ananda K Maharjan, Santosh Pradhan</p>
-
-</body>
+    <p>(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan</p>
+  </body>
 </html>


### PR DESCRIPTION
The previous wordlist included 𑐫𑑂 without zwj instead of 𑐫𑑂‌ with zwj. For example, 𑐩𑐫𑑂𑐖𑐸 instead of 𑐩𑐫𑑂‌𑐖𑐸
This has been corrected in the updated wordlist.