### PR TITLE
fix: pin @keymanapp/keyman-version to 16.0.138

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@keymanapp/keyman-version": "^16.0.138",
         "@keymanapp/lexical-model-compiler": "^16.0.138",
         "@keymanapp/models-types": "^16.0.138",
         "@types/node": "^18.11.18",
@@ -30,6 +31,7 @@
       "version": "16.0.138",
       "resolved": "https://registry.npmjs.org/@keymanapp/lexical-model-compiler/-/lexical-model-compiler-16.0.138.tgz",
       "integrity": "sha512-oVIWLJDXVR+PlJF3l13dQFseNZrM9ZqA6pGJ5yTCyg6O0IMe1PcQTW5Wy+4gNGbrYzQ59Jq/vhTX5znGUVjwRQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@keymanapp/keyman-version": "*",
         "@keymanapp/models-types": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/keymanapp/lexical-models#readme",
   "dependencies": {
+    "@keymanapp/keyman-version": "^16.0.138",
     "@keymanapp/lexical-model-compiler": "^16.0.138",
     "@keymanapp/models-types": "^16.0.138",
     "@types/node": "^18.11.18",
@@ -25,7 +26,7 @@
   },
   "devDependencies": {
     "chalk": "^2.4.2",
-    "xml2js": "^0.5.0",
-    "jszip": "^3.7.0"
+    "jszip": "^3.7.0",
+    "xml2js": "^0.5.0"
   }
 }


### PR DESCRIPTION
The @keymanapp/lexical-model-compiler package has unpinned versions for @keymanapp/keyman-version and @keymanapp/models-types. This led to a mismatch in module formats from 16.0 to 17.0. This patch tells npm to use the 16.0.138 version of @keymanapp/keyman-version.

I audited the 17.0 packages and found that they all appear to correctly pin the @keymanapp dependency versions in the deployed packages.

Should unblock #253.

Fixes: keymanapp/keyman#11503