### PR TITLE
chore: migrate description field from .model_info to .kps

### DIFF
--- a/experimental/ptg/ptg.nan-latn-tw.taigipoj/source/ptg.nan-latn-tw.taigipoj.model.kps
+++ b/experimental/ptg/ptg.nan-latn-tw.taigipoj/source/ptg.nan-latn-tw.taigipoj.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 PhahTaigi</Copyright>
     <Author URL="">PhahTaigi</Author>
     <Version URL="">1.0</Version>
+    <Description>PhahTaigi POJ Lexical Model</Description>
   </Info>
   <Files>
     <File>

--- a/release/ait/ait.mnw.mon/source/ait.mnw.mon.model.kps
+++ b/release/ait/ait.mnw.mon/source/ait.mnw.mon.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021 Anonta Mon</Copyright>
     <Author URL="mailto:monfonts@gmail.com">Anonta Mon</Author>
     <Version URL="">1.0</Version>
+    <Description>Mon predictive text lexical model.</Description>
   </Info>
   <Files>
     <File>

--- a/release/alfareh/alfareh.xsa.himyarit_musnad/source/alfareh.xsa.himyarit_musnad.model.kps
+++ b/release/alfareh/alfareh.xsa.himyarit_musnad/source/alfareh.xsa.himyarit_musnad.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© Riyadh Alfareh</Copyright>
     <Author URL="mailto:ralfareh@mtn.com.ye">رياض الفرح (Riyadh Alfareh)</Author>
     <Version URL="">1.1</Version>
+    <Description>Himyarit Musnad lexicon.</Description>
   </Info>
   <Files>
     <File>

--- a/release/aozcq/aozcq.rar-latn.cook_islands_maori/source/aozcq.rar-latn.cook_islands_maori.model.kps
+++ b/release/aozcq/aozcq.rar-latn.cook_islands_maori/source/aozcq.rar-latn.cook_islands_maori.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2021 Sally Akevai Nicholas, Yuri Oh, Brandon Zhou, Rolando Coto Solano, Victoria Quint</Copyright>
     <Author URL="">aozcq</Author>
     <Version URL="">1.2</Version>
+    <Description>Cook Islands Maori predictive text lexical model. Generated from texts collected by Sally Akevai Nicholas.</Description>
   </Info>
   <Files>
     <File>

--- a/release/av/av.eo.esperanto/source/av.eo.esperanto.model.kps
+++ b/release/av/av.eo.esperanto/source/av.eo.esperanto.model.kps
@@ -22,6 +22,7 @@
     <Author URL="mailto:a.vaccari@gmail.com">Andrea Vaccari</Author>
     <Version URL="">1.0</Version>
     <WebSite URL="https://esperatempo.altervista.org">https://esperatempo.altervista.org</WebSite>
+    <Description>Esperanto generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/benny_lin/benny_lin.id.kamus_indonesia/source/benny_lin.id.kamus_indonesia.model.kps
+++ b/release/benny_lin/benny_lin.id.kamus_indonesia/source/benny_lin.id.kamus_indonesia.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 Benny Lin</Copyright>
     <Author URL="">Benny Lin</Author>
     <Version URL="">1.0</Version>
+    <Description>Kamus Indonesia generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/bennylin/bennylin.jv-latn.bausastra_jawa/source/bennylin.jv-latn.bausastra_jawa.model.kps
+++ b/release/bennylin/bennylin.jv-latn.bausastra_jawa/source/bennylin.jv-latn.bausastra_jawa.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 Benny Lin</Copyright>
     <Author URL="">Benny Lin</Author>
     <Version URL="">1.0</Version>
+    <Description>Bausastra Jawa generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/diane/diane.nqo.nko/source/diane.nqo.nko.model.kps
+++ b/release/diane/diane.nqo.nko/source/diane.nqo.nko.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 Baba Mamadi Diane</Copyright>
     <Author URL="">Baba Mamadi Diane</Author>
     <Version URL="">1.0</Version>
+    <Description>N'Ko generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/dotland/dotland.hy.armenian/source/dotland.hy.armenian.model.kps
+++ b/release/dotland/dotland.hy.armenian/source/dotland.hy.armenian.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© Dotland</Copyright>
     <Author URL="mailto:tisarukhan@gmail.com">Tigran Sarukhanyan</Author>
     <Version URL="">1.2</Version>
+    <Description>Armenian generated from template</Description>
     <WebSite URL="https://github.com/dotland/mnemonic-kb-hy/blob/main/README.md">https://github.com/dotland/mnemonic-kb-hy/blob/main/README.md</WebSite>
   </Info>
   <Files>

--- a/release/dotland/dotland.ru.russian/source/dotland.ru.russian.model.kps
+++ b/release/dotland/dotland.ru.russian/source/dotland.ru.russian.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2022-2023 Dotland</Copyright>
     <Author URL="mailto:tisarukhan@gmail.com">Tigran Sarukhanyan</Author>
     <Version URL="">1.3</Version>
+    <Description>Russian generated from template</Description>
     <WebSite URL="https://github.com/dotland/mnemonic-kb-ru/blob/main/README.md">https://github.com/dotland/mnemonic-kb-ru/blob/main/README.md</WebSite>
   </Info>
   <Files>

--- a/release/gff/gff.am.gff_amharic/source/gff.am.gff_amharic.model.kps
+++ b/release/gff/gff.am.gff_amharic/source/gff.am.gff_amharic.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 Ge'ez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Ge'ez Frontier Foundation</Author>
     <Version URL="">1.0</Version>
+    <Description>Amharic Lexical Model derived from the UniLex word list for Amharic.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.awn.gff_awngi/source/gff.awn.gff_awngi.model.kps
+++ b/release/gff/gff.awn.gff_awngi/source/gff.awn.gff_awngi.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0</Version>
+    <Description>Awngi Lexical Model derived from a curated document corpus.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.byn.gff_blin/source/gff.byn.gff_blin.model.kps
+++ b/release/gff/gff.byn.gff_blin/source/gff.byn.gff_blin.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0.1</Version>
+    <Description>Blin Lexical Model derived from a curated document corpus.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.har.gff_harari/source/gff.har.gff_harari.model.kps
+++ b/release/gff/gff.har.gff_harari/source/gff.har.gff_harari.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.1</Version>
+    <Description>Harari Lexical Model derived from a curated document corpus.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
+++ b/release/gff/gff.sgw.gurage/source/gff.sgw.gurage.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 - 2021 Ge'ez Frontier Foundation</Copyright>
     <Author URL="">Ge'ez Frontier Foundation</Author>
     <Version URL="">1.1</Version>
+    <Description>Gurage Lexical Model using the 2018 orthography of Dr. Fekede Menuta.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.ti.gff_tigrinya/source/gff.ti.gff_tigrinya.model.kps
+++ b/release/gff/gff.ti.gff_tigrinya/source/gff.ti.gff_tigrinya.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 - 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.2</Version>
+    <Description>Tigrinya Lexical Model derived from the UniLex word list for Tigrinya.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/gff.ti_er.gff_tigrinya_eritrea.model.kps
+++ b/release/gff/gff.ti_er.gff_tigrinya_eritrea/source/gff.ti_er.gff_tigrinya_eritrea.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0.1</Version>
+    <Description>The Tigrinya-Eritrea lexical model is based on the content found from 131 issues of the Haddas Eritrea (ሓዳስ ኤርትራ) newspaper.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/gff.ti_et.gff_tigrinya_ethiopia.model.kps
+++ b/release/gff/gff.ti_et.gff_tigrinya_ethiopia/source/gff.ti_et.gff_tigrinya_ethiopia.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0.1</Version>
+    <Description>The Tigrinya-Ethiopia lexical model is based on the content found from 100 issues of the Wegahta (ወጋሕታ) newspaper.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.tig.gff_tigre/source/gff.tig.gff_tigre.model.kps
+++ b/release/gff/gff.tig.gff_tigre/source/gff.tig.gff_tigre.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0.2</Version>
+    <Description>Tigre Lexical Model derived from a curated document corpus.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gff/gff.xan.gff_xamtanga/source/gff.xan.gff_xamtanga.model.kps
+++ b/release/gff/gff.xan.gff_xamtanga/source/gff.xan.gff_xamtanga.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Geʾez Frontier Foundation</Copyright>
     <Author URL="mailto:yacob@geez.org">Geʾez Frontier Foundation</Author>
     <Version URL="">1.0</Version>
+    <Description>Xamtanga Lexical Model derived from a curated document corpus.</Description>
   </Info>
   <Files>
     <File>

--- a/release/gonzalez_quint_coto/gonzalez_quint_coto.cjp-latn.cabecar/source/gonzalez_quint_coto.cjp-latn.cabecar.model.kps
+++ b/release/gonzalez_quint_coto/gonzalez_quint_coto.cjp-latn.cabecar/source/gonzalez_quint_coto.cjp-latn.cabecar.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2021 Guillermo González, Victoria Quint, and Rolando Coto</Copyright>
     <Author URL="">Guillermo González, Victoria Quint, and Rolando Coto</Author>
     <Version URL="">1.2</Version>
+    <Description>Cabécar generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/iles/iles.chp.indigenous_nt/source/iles.chp.indigenous_nt.model.kps
+++ b/release/iles/iles.chp.indigenous_nt/source/iles.chp.indigenous_nt.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021-2023 ILES</Copyright>
     <Author URL="">ILES</Author>
     <Version URL="">0.2</Version>
+    <Description>This is a preliminary predictive text model for Chipewyan, (BCP47: chp)</Description>
   </Info>
   <Files>
     <File>

--- a/release/iles/iles.dgr.indigenous_nt/source/iles.dgr.indigenous_nt.model.kps
+++ b/release/iles/iles.dgr.indigenous_nt/source/iles.dgr.indigenous_nt.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021-2023 ILES</Copyright>
     <Author URL="">ILES</Author>
     <Version URL="">0.2</Version>
+    <Description>This is a preliminary predictive text model for Tłı̨chǫ, (BCP47: dgr)</Description>
   </Info>
   <Files>
     <File>

--- a/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps
+++ b/release/jo/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model/source/jo.isk-cyrl-tj.ishkashimi_cyrillic_minimal_model.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
     <Author URL="">JO</Author>
     <Version URL="">1.1</Version>
+    <Description>Ishkashimi Cyrillic minimal model generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps
+++ b/release/jo/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal/source/jo.wbl-cyrl-tj.wakhi_cyrillic_minimal.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2021 Tajik International Cultural Relations Organisation</Copyright>
     <Author URL="">JO</Author>
     <Version URL="">1.1</Version>
+    <Description>Wakhi Cyrillic generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/katelem/katelem.ann-latn.getat/source/katelem.ann-latn.getat.model.kps
+++ b/release/katelem/katelem.ann-latn.getat/source/katelem.ann-latn.getat.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020 - 2022 Rogers Katelem Edeh</Copyright>
     <Author URL="mailto:rogerskatelem@gmail.com">Rogers Katelem Edeh</Author>
     <Version URL="">1.1</Version>
+    <Description>Getat: a Lexical Model for the Obolo language of Nigeria.</Description>
   </Info>
   <Files>
     <File>

--- a/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
+++ b/release/nrc/nrc.en.mtnt/source/nrc.en.mtnt.model.kps
@@ -19,6 +19,7 @@
     <Copyright URL="">© 2019-2023 National Research Council Canada</Copyright>
     <Author URL="mailto:easantos@ualberta.ca">Eddie Antonio Santos</Author>
     <Version URL="">0.3.2</Version>
+    <Description>A unigram language model for English derived from the MTNT corpus &lt;http://www.cs.cmu.edu/~pmichel1/mtnt/&gt;. This corpus itself is gathered from Reddit, so it is unfiltered internet discussion. This is not humanity at its prettiest!</Description>
   </Info>
   <Files>
     <File>

--- a/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
+++ b/release/nrc/nrc.str.sencoten/source/nrc.str.sencoten.model.kps
@@ -12,6 +12,7 @@
     <Copyright URL="">© 2019-2023 Timothy Montler and the W̱SÁNEĆ School Board</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
     <Version>1.0.6</Version>
+    <Description>SENĆOŦEN (Saanich Dialect)</Description>
   </Info>
   <Files>
     <File>

--- a/release/okan_dale/okan_dale.lzz.laz_dictionary/source/okan_dale.lzz.laz_dictionary.model.kps
+++ b/release/okan_dale/okan_dale.lzz.laz_dictionary/source/okan_dale.lzz.laz_dictionary.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© Okan Dale</Copyright>
     <Author URL="">Okan Dale</Author>
     <Version URL="">1.0</Version>
+    <Description>Laz Dictionary generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/pme/pme.en-qp.postmodern_english_us_midland/source/pme.en-qp.postmodern_english_us_midland.model.kps
+++ b/release/pme/pme.en-qp.postmodern_english_us_midland/source/pme.en-qp.postmodern_english_us_midland.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2022, The Postmodern English Project</Copyright>
     <Author URL="mailto:postmodernenglish@gmail.com">The Postmodern English Project</Author>
     <Version URL="">1.0.3</Version>
+    <Description>Postmodern English US Midland Dictionary</Description>
     <WebSite URL="www.postmodernenglish.org">www.postmodernenglish.org</WebSite>
   </Info>
   <Files>

--- a/release/samar/samar.tk-arab.wl2/source/samar.tk-arab.wl2.model.kps
+++ b/release/samar/samar.tk-arab.wl2/source/samar.tk-arab.wl2.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2023 Samar</Copyright>
     <Author URL="">Samar</Author>
     <Version URL="">1.0</Version>
+    <Description>Lexical Model for Afghan Turkmen.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
+++ b/release/sapradhan/sapradhan.new-newa.nepal_bhasa/source/sapradhan.new-newa.nepal_bhasa.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">(c) 2020-2023 Ananda K Maharjan, Santosh Pradhan</Copyright>
     <Author URL="">Santosh Pradhan</Author>
     <Version URL="">2.3</Version>
+    <Description>Based on articles from nepalbhasatimes.com converted to Prachalit using https://www.hamroschool.com/a.php</Description>
   </Info>
   <Files>
     <File>

--- a/release/shavian_info/shavian_info.en-shaw.readlex/source/shavian_info.en-shaw.readlex.model.kps
+++ b/release/shavian_info/shavian_info.en-shaw.readlex/source/shavian_info.en-shaw.readlex.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">Shavian.info</Copyright>
     <Author URL="mailto:contact@shavian.info">Ed Greville</Author>
     <Version URL="">1.0</Version>
+    <Description>ReadLex generated from template</Description>
     <WebSite URL="https://www.shavian.info">https://www.shavian.info</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil.bcc-arab.upp_ptwl1/source/sil.bcc-arab.upp_ptwl1.model.kps
+++ b/release/sil/sil.bcc-arab.upp_ptwl1/source/sil.bcc-arab.upp_ptwl1.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">1.2.2</Version>
+    <Description>Balochi in Arabic script.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.bcc-latn.upp_ptwl1/source/sil.bcc-latn.upp_ptwl1.model.kps
+++ b/release/sil/sil.bcc-latn.upp_ptwl1/source/sil.bcc-latn.upp_ptwl1.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2021 SIL International</Copyright>
     <Author URL="">RL</Author>
     <Version URL="">1.2.2</Version>
+    <Description>sil.bcc-latn.upp_ptwl1 generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.brb.brao/source/sil.brb.brao.model.kps
+++ b/release/sil/sil.brb.brao/source/sil.brb.brao.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021 SIL International</Copyright>
     <Author URL=""></Author>
     <Version URL="">1.0</Version>
+    <Description>This model was created based on a word list provided by the linguist working on the language.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.cmo.bw/source/sil.cmo.bw.model.kps
+++ b/release/sil/sil.cmo.bw/source/sil.cmo.bw.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021 - 2022 SIL International</Copyright>
     <Author URL=""></Author>
     <Version URL="">1.1</Version>
+    <Description>Bunong Wordlist is based on the Bible wordlist of 1,157 unique entries with their frequencies.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.dzg.lexique/source/sil.dzg.lexique.model.kps
+++ b/release/sil/sil.dzg.lexique/source/sil.dzg.lexique.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2022 SIL Tchad</Copyright>
     <Author URL="">SIL Tchad</Author>
     <Version URL="">1.1</Version>
+    <Description>Lexique Dazaga</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
+++ b/release/sil/sil.glk-arab.ptwl1/source/sil.glk-arab.ptwl1.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">RL</Author>
     <Version URL="">1.0.6</Version>
+    <Description>ptwl1 generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
+++ b/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">1.0</Version>
+    <Description>Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. The word list obtained has 1,276 words.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.kjg-laoo.ptwl1/source/sil.kjg-laoo.ptwl1.model.kps
+++ b/release/sil/sil.kjg-laoo.ptwl1/source/sil.kjg-laoo.ptwl1.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2023 SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">1.1</Version>
+    <Description>ptwl1 generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.km.cnd/source/sil.km.cnd.model.kps
+++ b/release/sil/sil.km.cnd/source/sil.km.cnd.model.kps
@@ -20,7 +20,7 @@
     <Copyright URL="">© SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">0.1</Version>
-    <Description>This is a list of all headwords from the \"Chuon Nath 2.0.ods\" without word freq. It has been modified to ensure its suitability for the predictive text. After cleaning up, there are 17,190 entries.</Description>
+    <Description>This is a list of all headwords from the "Chuon Nath 2.0.ods" without word freq. It has been modified to ensure its suitability for the predictive text. After cleaning up, there are 17,190 entries.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.km.cnd/source/sil.km.cnd.model.kps
+++ b/release/sil/sil.km.cnd/source/sil.km.cnd.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">0.1</Version>
+    <Description>This is a list of all headwords from the \"Chuon Nath 2.0.ods\" without word freq. It has been modified to ensure its suitability for the predictive text. After cleaning up, there are 17,190 entries.</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.km.ggc/source/sil.km.ggc.model.kps
+++ b/release/sil/sil.km.ggc/source/sil.km.ggc.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© SIL International</Copyright>
     <Author URL="">SIL International</Author>
     <Version URL="">1.1</Version>
+    <Description>Google Crawler generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.tea.dict/source/sil.tea.dict.model.kps
+++ b/release/sil/sil.tea.dict/source/sil.tea.dict.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© SIL Malaysia</Copyright>
     <Author URL="">SIL</Author>
     <Version URL="">1.0</Version>
+    <Description>Temiar dictionary generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil.tuq.lexique/source/sil.tuq.lexique.model.kps
+++ b/release/sil/sil.tuq.lexique/source/sil.tuq.lexique.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2022 SIL Tchad</Copyright>
     <Author URL="mailto:langtech_chad@sil.org">SIL Tchad</Author>
     <Version URL="">1.1</Version>
+    <Description>Tedaga lexique</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil_cameroon.mct.mengisa/source/sil_cameroon.mct.mengisa.model.kps
+++ b/release/sil/sil_cameroon.mct.mengisa/source/sil_cameroon.mct.mengisa.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© SIL Cameroon</Copyright>
     <Author URL="">SIL Cameroon</Author>
     <Version URL="">1.0</Version>
+    <Description>Mengisa generated from template</Description>
   </Info>
   <Files>
     <File>

--- a/release/sil/sil_senegal.bsc.wl1/source/sil_senegal.bsc.wl1.model.kps
+++ b/release/sil/sil_senegal.bsc.wl1/source/sil_senegal.bsc.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>Predictive text model for Oniyan (bsc, Senegal), based on a word list with casing enabled.</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.cou.wl1/source/sil_senegal.cou.wl1.model.kps
+++ b/release/sil/sil_senegal.cou.wl1/source/sil_senegal.cou.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.0.1</Version>
+    <Description>predictive text model for Konyagi (cou, Senegal), based on a word list</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.dyo.wl1/source/sil_senegal.dyo.wl1.model.kps
+++ b/release/sil/sil_senegal.dyo.wl1/source/sil_senegal.dyo.wl1.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2022-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Jola Fonyi (dyo, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.gsl-arab.wl2/source/sil_senegal.gsl-arab.wl2.model.kps
+++ b/release/sil/sil_senegal.gsl-arab.wl2/source/sil_senegal.gsl-arab.wl2.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">©2022-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.2.1</Version>
+    <Description>predictive text model for Gusilay (gsl, Senegal) in Ajami, based on a word list</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.gsl.wl2/source/sil_senegal.gsl.wl2.model.kps
+++ b/release/sil/sil_senegal.gsl.wl2/source/sil_senegal.gsl.wl2.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.3.0</Version>
+    <Description>predictive text model for Gusilay (gsl, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.krx.wl1/source/sil_senegal.krx.wl1.model.kps
+++ b/release/sil/sil_senegal.krx.wl1/source/sil_senegal.krx.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>Predictive text model for Karon (krx, Senegal), based on a word list with casing enabled.</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.ndv.wl1/source/sil_senegal.ndv.wl1.model.kps
+++ b/release/sil/sil_senegal.ndv.wl1/source/sil_senegal.ndv.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">sil_senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Ndut (ndv, Senegal), based on a word list with casing</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.sav.wl1/source/sil_senegal.sav.wl1.model.kps
+++ b/release/sil/sil_senegal.sav.wl1/source/sil_senegal.sav.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Saafi-Saafi (sav, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.snf.wl1/source/sil_senegal.snf.wl1.model.kps
+++ b/release/sil/sil_senegal.snf.wl1/source/sil_senegal.snf.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Noon (snf, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.srr.texts/source/sil_senegal.srr.texts.model.kps
+++ b/release/sil/sil_senegal.srr.texts/source/sil_senegal.srr.texts.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL International</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Serer-Sine (srr, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org">senegal.sil.org</WebSite>
   </Info>
   <Files>

--- a/release/sil/sil_senegal.wo.wl1/source/sil_senegal.wo.wl1.model.kps
+++ b/release/sil/sil_senegal.wo.wl1/source/sil_senegal.wo.wl1.model.kps
@@ -21,6 +21,7 @@
     <Copyright URL="">© 2021-2023 SIL Senegal</Copyright>
     <Author URL="mailto:academic_computing_seb@sil.org">SIL Senegal</Author>
     <Version URL="">1.1.0</Version>
+    <Description>predictive text model for Wolof (wo, Senegal), based on a word list with casing enabled</Description>
     <WebSite URL="senegal.sil.org/">senegal.sil.org/</WebSite>
   </Info>
   <Files>

--- a/release/srla/srla.th.ct5k/source/srla.th.ct5k.model.kps
+++ b/release/srla/srla.th.ct5k/source/srla.th.ct5k.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2021 Sebastian Restrepo &amp; LatamAsia</Copyright>
     <Author URL="">Sebastian Restrepo &amp; LatamAsia</Author>
     <Version URL="">1.0</Version>
+    <Description>This wordlist was created based on Chulalongkorn University top 5000 Thai frequency list (http://ling.arts.chula.ac.th/TNC/category.php?id=58&amp;).</Description>
   </Info>
   <Files>
     <File>

--- a/release/tbm/tbm.eo-shaw.esperanto_sxava/source/tbm.eo-shaw.esperanto_sxava.model.kps
+++ b/release/tbm/tbm.eo-shaw.esperanto_sxava/source/tbm.eo-shaw.esperanto_sxava.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© Tomás Briones M.</Copyright>
     <Author URL="">Tomás Briones M.</Author>
     <Version URL="">1.0</Version>
+    <Description>Esperanto_sxava lexical model. It includes more than 45.000 words in Esperanto, using the shavian alphabet. The words were taken from the dictionary Plena Ilustrita Vortaro. - Ĝi inkludas pli da 45.000 words in Esperanto, uzante la sxavan alfabeton. La vortoj estis prenitaj el Plena Ilustrita Vortaro</Description>
   </Info>
   <Files>
     <File>

--- a/release/tbm/tbm.eo.esperanto/source/tbm.eo.esperanto.model.kps
+++ b/release/tbm/tbm.eo.esperanto/source/tbm.eo.esperanto.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© Tomás Briones M.</Copyright>
     <Author URL="">Tomás Briones M.</Author>
     <Version URL="">1.0</Version>
+    <Description>Esperanto generated from template</Description>
     <WebSite URL="http://www.lastajneuxronoj.wordpress.com">http://www.lastajneuxronoj.wordpress.com</WebSite>
   </Info>
   <Files>

--- a/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.kps
+++ b/release/wyc_eth/wyc_eth.mym-latn.me_en/source/wyc_eth.mym-latn.me_en.model.kps
@@ -20,6 +20,7 @@
     <Copyright URL="">© 2020-2023 Wycliffe Ethiopia</Copyright>
     <Author URL="">Wycliffe Ethiopia</Author>
     <Version URL="">1.2</Version>
+    <Description>Me'en based on wordlist</Description>
   </Info>
   <Files>
     <File>

--- a/sample/example/example.crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
+++ b/sample/example/example.crk.wordlist_wahkohtowin/source/example.crk.wordlist_wahkohtowin.model.kps
@@ -12,6 +12,7 @@
     <Copyright URL="">© 2019 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
     <Version>0.1.2</Version>
+    <Description>Example wordlist model for Plains Cree, using a wordlist exported from Google Sheets. The words are terms for kinship (wahkohtowin).</Description>
   </Info>
   <Files>
     <File>

--- a/sample/example/example.en.custom/source/example.en.custom.model.kps
+++ b/sample/example/example.en.custom/source/example.en.custom.model.kps
@@ -12,6 +12,7 @@
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
     <Version>0.1.4</Version>
+    <Description>Example custom model template for English language.</Description>
   </Info>
   <Files>
     <File>

--- a/sample/example/example.en.custom_word_breaker/source/example.en.custom_word_breaker.model.kps
+++ b/sample/example/example.en.custom_word_breaker/source/example.en.custom_word_breaker.model.kps
@@ -12,6 +12,7 @@
     <Copyright URL="">© 2020 National Research Council Canada</Copyright>
     <Author URL="mailto:Eddie.Santos@nrc-cnrc.gc.ca">Eddie Antonio Santos</Author>
     <Version>0.1.0</Version>
+    <Description>Example lexical model with custom word breaker.</Description>
   </Info>
   <Files>
     <File>

--- a/sample/example/example.en.wordlist/source/example.en.wordlist.model.kps
+++ b/sample/example/example.en.wordlist/source/example.en.wordlist.model.kps
@@ -12,6 +12,7 @@
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:marc@keyman.com">Marc Durdin</Author>
     <Version>0.1.4</Version>
+    <Description>Example wordlist model template for English language.</Description>
   </Info>
   <Files>
     <File>

--- a/sample/example/example.ta.wordlist/source/example.ta.wordlist.model.kps
+++ b/sample/example/example.ta.wordlist/source/example.ta.wordlist.model.kps
@@ -17,6 +17,7 @@
   <Info>
     <Name URL="">Example (Tamil) Template Wordlist Model</Name>
     <Version>1.0</Version>
+    <Description>Example wordlist model template for Tamil language.</Description>
     <Copyright URL="">© 2019 SIL International</Copyright>
     <Author URL="mailto:support@keyman.com">Darcy Wong</Author>
   </Info>


### PR DESCRIPTION
The model info compiler no longer uses the .model_info data, but we never migrated the relevant description field to the .kps file.

Note: the model info compiler should either error on missing Description field or fill in a default value from the Name. (Same for keyboard info compiler.)

Relates-to: keymanapp/keyman#12198
Relates-to: keymanapp/keyman#12202