### PR TITLE
chore(cathaylab.nan-latn-035.teochew): add also .model_info for teochew

### DIFF
--- a/release/cathaylab/cathaylab.nan-latn-035.teochew/cathaylab.nan-latn-035.teochew.model_info
+++ b/release/cathaylab/cathaylab.nan-latn-035.teochew/cathaylab.nan-latn-035.teochew.model_info
@@ -1,0 +1,4 @@
+{
+    "license": "mit",
+    "description": "teochew model for Tiê-chiu Pe̍h-ūe-jī"
+}


### PR DESCRIPTION
I didn't realize this was also missing. .model_info are still required, will be removed shortly.