### PR TITLE
chore: add .model_info for burushos.bsk.burushaski

### DIFF
--- a/release/burushos/burushos.bsk.burushaski/burushos.bsk.burushaski.model_info
+++ b/release/burushos/burushos.bsk.burushaski/burushos.bsk.burushaski.model_info
@@ -1,0 +1,4 @@
+{
+    "license": "mit",
+    "description": "This is a lexical model for the Burushaski language keyboard"
+}


### PR DESCRIPTION
This is needed temporarily until #270 merges (and will need removal again in #271).