### PR TITLE
[sil.km.gcc] Fix custom wordbreaker output (version bump to build)

### DIFF
--- a/release/sil/sil.km.ggc/HISTORY.md
+++ b/release/sil/sil.km.ggc/HISTORY.md
@@ -1,6 +1,10 @@
 Google Crawler Change History
 ====================
 
+1.2 (2024-09-16)
+----------------
+* Fix custom wordkbreaker output format
+
 1.1 (2024-03-06)
 ----------------
 * bump version number for "[sil.km.ggc] remove space after words #241"

--- a/release/sil/sil.km.ggc/README.md
+++ b/release/sil/sil.km.ggc/README.md
@@ -1,8 +1,6 @@
 Google Crawler lexical model
 ===================
 
-Version 1.1
-
 Description
 -----------
 This is a wordlist from [Google Corpus Crawler](https://github.com/google/corpuscrawler?tab=readme-ov-file).  After cleaning up the data using 

--- a/release/sil/sil.km.ggc/sil.km.ggc.kpj
+++ b/release/sil/sil.km.ggc/sil.km.ggc.kpj
@@ -19,7 +19,7 @@
       <ID>id_a02fd3894fae146aa99da3213c3509d4</ID>
       <Filename>sil.km.ggc.model.kps</Filename>
       <Filepath>source\sil.km.ggc.model.kps</Filepath>
-      <FileVersion>1.1</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Khmer Google Crawler</Name>

--- a/release/sil/sil.km.ggc/source/sil.km.ggc.model.kps
+++ b/release/sil/sil.km.ggc/source/sil.km.ggc.model.kps
@@ -19,7 +19,7 @@
     <Name URL="">Khmer Google Crawler</Name>
     <Copyright URL="">© SIL International</Copyright>
     <Author URL="">SIL International</Author>
-    <Version URL="">1.1</Version>
+    <Version URL="">1.2</Version>
     <Description>Google Crawler generated from template</Description>
   </Info>
   <Files>


### PR DESCRIPTION
This follows #265 which fixed the custom wordkbreaker output for sil.km.gcc. We held off on incrementing the version on that PR in anticipation of consolidating it with the repo-wide rebuild of #274.

@mcdurdin requested
> Can we split the compiler version update into its own PR please? Then this becomes just maintenance, and issues such as the sil.lzz.laz update happening simultaneously to this won't have an impact.

So this PR will happen before #266 (which uses 17.0.329), so this build will happen with 17.0.328 stable compiler.

265 266