### PR TITLE
fix[sil.jra-khmr.jarai] follow the improved script of word prediction

### DIFF
--- a/release/sil/sil.jra-khmr.jarai/HISTORY.md
+++ b/release/sil/sil.jra-khmr.jarai/HISTORY.md
@@ -1,6 +1,10 @@
 Jarai Change History
 ====================
 
+1.2 (2024-10-28)
+----------------
+* Follow the updated script of text prediction. This script avoids the removal of punctuation marks or symbols that appear before the selected predictive word.
+
 1.1 (2024-09-16)
 ----------------
 * Rebuild with 17.0.329 compiler to address missing low-frequency words

--- a/release/sil/sil.jra-khmr.jarai/LICENSE.md
+++ b/release/sil/sil.jra-khmr.jarai/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2022 SIL International
+Copyright © 2021 - 2024 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil.jra-khmr.jarai/LICENSE.md
+++ b/release/sil/sil.jra-khmr.jarai/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2021 - 2024 SIL Global
+Copyright © 2022 - 2024 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/release/sil/sil.jra-khmr.jarai/README.md
+++ b/release/sil/sil.jra-khmr.jarai/README.md
@@ -1,8 +1,6 @@
 Jarai lexical model
 ===================
 
-Version 1.0
-
 Description
 -----------
 Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. The word list obtained has 1,276 words.

--- a/release/sil/sil.jra-khmr.jarai/sil.jra-khmr.jarai.kpj
+++ b/release/sil/sil.jra-khmr.jarai/sil.jra-khmr.jarai.kpj
@@ -3,7 +3,6 @@
   <Options>
     <BuildPath>$PROJECTPATH\build</BuildPath>
     <CompilerWarningsAsErrors>True</CompilerWarningsAsErrors>
-    <WarnDeprecatedCode>True</WarnDeprecatedCode>
     <CheckFilenameConventions>True</CheckFilenameConventions>
     <ProjectType>lexicalmodel</ProjectType>
   </Options>
@@ -12,19 +11,19 @@
       <ID>id_e3f7967b333ad7409f039b3f170fc751</ID>
       <Filename>sil.jra-khmr.jarai.model.ts</Filename>
       <Filepath>source\sil.jra-khmr.jarai.model.ts</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.3</FileVersion>
       <FileType>.ts</FileType>
     </File>
     <File>
       <ID>id_43442e7eba97b21424fabbc107e2e310</ID>
       <Filename>sil.jra-khmr.jarai.model.kps</Filename>
       <Filepath>source\sil.jra-khmr.jarai.model.kps</Filepath>
-      <FileVersion>1.0</FileVersion>
+      <FileVersion>1.3</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Jarai</Name>
-        <Copyright>© SIL International</Copyright>
-        <Version>1.0</Version>
+        <Copyright>© SIL Global</Copyright>
+        <Version>1.3</Version>
       </Details>
     </File>
     <File>
@@ -77,6 +76,14 @@
       <Filepath>source\readme.htm</Filepath>
       <FileVersion></FileVersion>
       <FileType>.htm</FileType>
+      <ParentFileID>id_43442e7eba97b21424fabbc107e2e310</ParentFileID>
+    </File>
+    <File>
+      <ID>id_c296b5df3dc126e219e0173fcbc1baec</ID>
+      <Filename>LICENSE.md</Filename>
+      <Filepath>source\..\LICENSE.md</Filepath>
+      <FileVersion></FileVersion>
+      <FileType>.md</FileType>
       <ParentFileID>id_43442e7eba97b21424fabbc107e2e310</ParentFileID>
     </File>
   </Files>

--- a/release/sil/sil.jra-khmr.jarai/sil.jra-khmr.jarai.kpj
+++ b/release/sil/sil.jra-khmr.jarai/sil.jra-khmr.jarai.kpj
@@ -11,19 +11,19 @@
       <ID>id_e3f7967b333ad7409f039b3f170fc751</ID>
       <Filename>sil.jra-khmr.jarai.model.ts</Filename>
       <Filepath>source\sil.jra-khmr.jarai.model.ts</Filepath>
-      <FileVersion>1.3</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.ts</FileType>
     </File>
     <File>
       <ID>id_43442e7eba97b21424fabbc107e2e310</ID>
       <Filename>sil.jra-khmr.jarai.model.kps</Filename>
       <Filepath>source\sil.jra-khmr.jarai.model.kps</Filepath>
-      <FileVersion>1.3</FileVersion>
+      <FileVersion>1.2</FileVersion>
       <FileType>.kps</FileType>
       <Details>
         <Name>Jarai</Name>
         <Copyright>© SIL Global</Copyright>
-        <Version>1.3</Version>
+        <Version>1.2</Version>
       </Details>
     </File>
     <File>

--- a/release/sil/sil.jra-khmr.jarai/source/readme.htm
+++ b/release/sil/sil.jra-khmr.jarai/source/readme.htm
@@ -18,7 +18,7 @@
     Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. The word list obtained has 1,276 words.
 </p>
 
-<p>© SIL International</p>
+<p>Copyright © SIL Global</p>
 
 </body>
 </html>

--- a/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
+++ b/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
@@ -19,7 +19,7 @@
     <Name URL="">Jarai</Name>
     <Copyright URL="">© SIL Global</Copyright>
     <Author URL="">SIL Global</Author>
-    <Version URL="">1.3</Version>
+    <Version URL="">1.2</Version>
     <Description>Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. The word list obtained has 1,276 words.</Description>
   </Info>
   <Files>

--- a/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
+++ b/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.kps
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package>
   <System>
-    <KeymanDeveloperVersion>15.0.260.0</KeymanDeveloperVersion>
+    <KeymanDeveloperVersion>17.0.330</KeymanDeveloperVersion>
     <FileVersion>12.0</FileVersion>
   </System>
   <Options>
@@ -17,9 +17,9 @@
   </StartMenu>
   <Info>
     <Name URL="">Jarai</Name>
-    <Copyright URL="">© SIL International</Copyright>
-    <Author URL="">SIL International</Author>
-    <Version URL="">1.1</Version>
+    <Copyright URL="">© SIL Global</Copyright>
+    <Author URL="">SIL Global</Author>
+    <Version URL="">1.3</Version>
     <Description>Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. The word list obtained has 1,276 words.</Description>
   </Info>
   <Files>

--- a/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.ts
+++ b/release/sil/sil.jra-khmr.jarai/source/sil.jra-khmr.jarai.model.ts
@@ -9,8 +9,49 @@
 const source: LexicalModelSource = {
   format: 'trie-1.0',
   sources: ['wordlist.tsv'],
-  wordBreaker: function(str: string) {
-    return str.split(/\s/).map(function(token) {
+  wordBreaker: function (str) {
+  const tokens = str.split(/\s|\u200b/);
+
+  for(let i=0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if(token.length == 1) {
+      continue;
+    }
+
+    // Certain punctuation marks should be considered a separate token from the word they're next to.
+    const punctuationMarks = ['«', '»', '$', '#', ',', '.', ';' /* add extras here */];
+    const punctSplitIndices = [];
+
+    // Find if and where each mark exists within the token
+    for(let i = 0; i < punctuationMarks.length; i++) {
+      const split = token.indexOf(punctuationMarks[i]);
+      if(split >= 0) {
+        punctSplitIndices.push(split);
+      }
+    }
+
+    // Sort and pick the earliest mark's location.  If none exists, use -1.
+    punctSplitIndices.sort();
+    const splitPoint = punctSplitIndices[0] === undefined ? -1 : punctSplitIndices[0];
+
+    if(splitPoint > -1) {
+      const left = token.substring(0, splitPoint);  // (0, -1) => ''
+      const punct = token.substring(splitPoint, splitPoint+1);
+      const right = token.substring(splitPoint+1);  // Starting past the end of the string => ''
+
+      if(left) {
+        tokens.splice(i++, 0, left);
+      }
+      tokens.splice(i++, 1, punct);
+      if(right) {
+        tokens.splice(i, 0, right);
+      }
+      // Ensure that the next iteration puts `i` immediately after the punctuation token... even if
+      // there was a `right` portion, as it may have extra marks that also need to be spun off.
+      i--;
+    }
+   }
+   return tokens.map(function(token) {
       return {
         left: str.indexOf(token),
         start: str.indexOf(token),
@@ -19,6 +60,9 @@ const source: LexicalModelSource = {
         text: token
       }
     });
-  }
+},
+punctuation: {
+    insertAfterWord: "\u0020"
+}
 };
 export default source;

--- a/release/sil/sil.jra-khmr.jarai/source/welcome.htm
+++ b/release/sil/sil.jra-khmr.jarai/source/welcome.htm
@@ -18,7 +18,7 @@
     Jarai lexical model is created for Jarai ចារាយ (SIL) keyboard. It will be automatically installed together with the keyboard. It can also be installed manually using the package of this model.
 </p>
 
-<p>© SIL International</p>
+<p>Copyright © SIL Global</p>
 
 </body>
 </html>


### PR DESCRIPTION
fixes: #235 and #236

With the specified punctuation marks and symbols in the variable, the word from the suggestion bar won't remove them when selected.
![image](https://github.com/user-attachments/assets/05aea3a7-7057-4c0c-94d2-876c1b8b191e)
