### PR TITLE
chore(chechen_language.ce-latn.chechen): remove https url from email field

### DIFF
--- a/release/chechen_language/chechen_language.ce-latn.chechen/source/chechen_language.ce-latn.chechen.model.kps
+++ b/release/chechen_language/chechen_language.ce-latn.chechen/source/chechen_language.ce-latn.chechen.model.kps
@@ -18,7 +18,7 @@
   <Info>
     <Name URL="">Chechen Latin Dictionary</Name>
     <Copyright URL="https://github.com/chechen-language/lexical-models">Copyright © Chechen Languages</Copyright>
-    <Author URL="https://github.com/chechen-language">Chechen Language Team</Author>
+    <Author URL="">Chechen Language Team</Author>
     <Version URL="">1.1</Version>
     <Description URL="">Lexical model for the Chechen language using the 1992 Latin script. Word forms are sourced from the corpus at corpora.dosham.info, created by a member of our team and maintained as part of our efforts to support the Chechen language.</Description>
   </Info>


### PR DESCRIPTION
The author URL field only supports an email address at this time. No version bump required, this impacts only the compiler, picked up with v18.0 beta compiler