### PR TITLE
fix: include missing parameter for rsync_to_downloads_keyman_com call

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -29,7 +29,7 @@ fi
 
 . "$MODELROOT/servervars.sh"
 . "$MODELROOT/resources/util.inc.sh"
-. "$MODELROOT/resources/rsync-tools.sh"
+. "$MODELROOT/resources/rsync-tools.inc.sh"
 
 function run {
 
@@ -50,7 +50,7 @@ function run {
   upload_models_by_target
 
   zip_model_info
-  rsync_to_downloads_keyman_com "$CI_CACHE/data/" data/
+  rsync_to_downloads_keyman_com "$CI_CACHE/data/" data/ false
 }
 
 ##

--- a/resources/rsync-tools.inc.sh
+++ b/resources/rsync-tools.inc.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+# shellcheck shell=bash
+# Keyman is copyright (C) SIL Global. MIT License.
 
 ##
 ## Use rsync to upload new files from a folder


### PR DESCRIPTION
Also renames rsync-tools.sh to rsync-tools.inc.sh

Fixes: #326